### PR TITLE
week11

### DIFF
--- a/nana/week11/Main_16234_인구이동.java
+++ b/nana/week11/Main_16234_인구이동.java
@@ -5,8 +5,75 @@ import java.io.InputStreamReader;
 import java.util.StringTokenizer;
 
 public class Main_16234_인구이동 {
+
+	static class Point {
+		int x, y;
+
+		public Point(int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		@Override
+		public String toString() {
+			return "Point [x=" + x + ", y=" + y + "]";
+		}
+
+	}
+
 	private static int N, L, R, date;
 	private static int[][] population;
+	private static int[][] delta = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } };
+	private static boolean[][] isVisited;
+	private static List<Point> select;
+	private static boolean moved; // 인구 이동의 유무
+
+	private static void bfs(int x, int y) {
+		select = new ArrayList<>();
+		Queue<Point> q = new ArrayDeque<>();
+
+		q.add(new Point(x, y));
+		select.add(new Point(x, y));
+		isVisited[x][y] = true;
+
+		while (!q.isEmpty()) {
+			Point p = q.poll();
+
+			for (int[] d : delta) {
+				int nx = p.x + d[0];
+				int ny = p.y + d[1];
+
+				if (nx < 0 || ny < 0 || nx >= N || ny >= N)
+					continue;
+
+				int n = Math.abs(population[p.x][p.y] - population[nx][ny]);
+
+				if (!isVisited[nx][ny] && n >= L && n <= R) {
+					isVisited[nx][ny] = true;
+					q.add(new Point(nx, ny));
+					select.add(new Point(nx, ny));
+				}
+			}
+
+		}
+
+		int sum = 0;
+		for (Point s : select) {
+			sum += population[s.x][s.y];
+		}
+
+		if (select.size() != 1) {
+
+			int replace = sum / select.size();
+
+			for (Point s : select) {
+				population[s.x][s.y] = replace;
+			}
+
+			moved = true;
+		}
+
+	}
 
 	public static void main(String[] args) throws Exception {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -17,15 +84,34 @@ public class Main_16234_인구이동 {
 		R = Integer.parseInt(st.nextToken()); // 인구수의 차이가 L 이상 R 이하
 
 		population = new int[N][N];
+		date = 0;
 
 		for (int i = 0; i < N; i++) {
 			st = new StringTokenizer(br.readLine());
 			for (int j = 0; j < N; j++) {
-				population = new int[i][j];
+				population[i][j] = Integer.parseInt(st.nextToken());
 			}
 		}
 
 		// 인구가 이동하는 경우는 인접한 국가의 인구수 차이가 L 이상 R 이하인 경우
+
+		while (true) {
+
+			isVisited = new boolean[N][N];
+			moved = false;
+
+			for (int i = 0; i < N; i++) {
+				for (int j = 0; j < N; j++) {
+					if (!isVisited[i][j])
+						bfs(i, j);
+				}
+			}
+
+			if (!moved)
+				break;
+
+			date++;
+		}
 
 		System.out.println(date);
 

--- a/nana/week11/Main_16234_인구이동.java
+++ b/nana/week11/Main_16234_인구이동.java
@@ -2,6 +2,10 @@ package ssafy.study.week11;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
 import java.util.StringTokenizer;
 
 public class Main_16234_인구이동 {

--- a/nana/week11/Main_28066_타노스는요세푸스가밉다.java
+++ b/nana/week11/Main_28066_타노스는요세푸스가밉다.java
@@ -18,6 +18,8 @@ public class Main_28066_타노스는요세푸스가밉다 {
 		}
 
 		while (true) {
+
+			// q의 크기가 K보다 작으면 가장 앞의 숫자 하나만 남을 때까지 숫자를 다 빼낸다.
 			if (q.size() < K) {
 				q.offer(q.poll());
 				while (q.size() != 1) {
@@ -28,11 +30,14 @@ public class Main_28066_타노스는요세푸스가밉다 {
 
 			q.offer(q.poll());
 
+			// 첫번째 숫자는 이미 뺐기 때문에 K-1번 동안 숫자를 뺀다
 			for (int i = 0; i < K - 1; i++) {
 				q.poll();
 			}
 
 		}
+
+		// 마지막 남은 수를 꺼내서 출력
 		System.out.println(q.poll());
 	}
 }


### PR DESCRIPTION
## 🔍 개요
+ close #18 

## ✔️ 문제 풀이 진행 사항
+ 문제 1 백준_1541_잃어버린괄호 - 완료
+ 문제 2 백준_16234_인구이동 - 미완료
+ 문제 3 백준_16922_로마숫자만들기 - 완료
+ 문제 4 백준_1976_여행가자 - 완료
+ 문제 5 백준_28066_타노스는요세푸스가밉다 - 완료


## 📝 문제 풀이 전략 및 실제 풀이 방법
**문제 1**
부호가 + 와 - 만 존재하기 때문에 - 기호를 기준으로 모든 식을 나누어 괄호로 묶으면 가장 작은 수를 구할 수 있다. 
예를 들어 문제의 예시에 나온 **55-50+40** 은 (55) - (50+40) 의 경우 가장 작은 수가 나온다.
split 이나 StringTokenizer 를 이용해서 부호를 기준으로 자르기만 하면 된다.

**문제 2**
BFS를 이용해 연합 가능한 국가를 찾아준 뒤,  연합 리스트에 국가의 위치를 넣었다.
해당 연합 내의 국가의 인구 수를 더하고, 리스트 크기로 나눈 뒤 연합에 속한 국가의 인구 수를 바꿔준다. 
이 작업에서 인구 이동을 시키는 while문을 빠져나오는 방법을 고민했는데, 
결국 다른 스터디원의 코드를 보고 boolean 값을 하나 선언해서 while문을 빠져나올 수 있었다.

**문제 3**
문제에서 언급 했지만, 순서가 중요하지 않아서 “중복조합”으로 풀이할 수 있었다.
하지만 나올 수 있는 모든 숫자의 “종류”를 찾아야 하기 때문에 
Set에 결과값을 넣어서 중복을 제거하고, set의 크기를 출력했다.

**문제 4**
입력을 받고 길이 있는 곳만 dfs를 돌리면 쉽게 풀 수 있었다. 
계획한 도시를 방문하는 것이 아니라 돌고 돌더라도 마지막에 계획한 도시에 방문 했기만 하면 되는 문제여서, 길이 있는 곳을 통해 끝까지 여행을 하게 만들었다. 
마지막에 방문 배열을 검사하는 부분을 만들었는데, 
만약 dfs를 통해 갈 수 있는 모든 도시를 돌고 나서도 계획한 도시에 방문하지 못했다면 해당 계획은 실패한 것으로 보고 결과에 NO를 출력하였다.

**문제 5**
K번째까지 뽑는다는 의미는 가장 처음 정렬에서 K번째까지 뽑는다는 의미이다. 
만약 N=5, K=4 라면 1 2 3 4 5 일 때, 4까지의 숫자를 의미한다.
1. 큐에 1부터 N까지의 숫자를 넣는다.
2. 첫번째 숫자를 뺀 뒤 다시 가장 뒤에 넣는다.
3. K-1 번 (첫번째 숫자를 먼저 뺐기 때문) 큐에서 숫자를 뺀다.
** 만약 큐의 크기가 K보다 작다면 가장 앞의 숫자 하나만 남을 때까지 숫자를 빼낸다.

## 🧐 참고 사항


## 📄 Reference

