### PR TITLE
week12

### DIFF
--- a/nana/week12/Main_10159_저울.java
+++ b/nana/week12/Main_10159_저울.java
@@ -1,0 +1,69 @@
+package study.week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_10159_저울 {
+    private static int N, M;
+    private static int[][] num;
+
+    private static int count(int n) {
+        int cnt = 0;
+
+        for (int i = 1; i <= N; i++) {
+            // 크거나 작으면 확인 가능하기 때문에 두군데 모두 0인 경우에만 알 수 없음
+            if (num[n][i] == 0 && num[i][n] == 0)
+                cnt++;
+        }
+
+        return cnt - 1; // 자기자신은 제외
+    }
+
+    private static void floyd() {
+        // 중간에 하나를 통해서 크기 비교가 가능하면
+        // 크기를 알 수 있기 때문에 1로 바꿔줌
+        for (int k = 1; k <= N; k++) {
+            for (int i = 1; i <= N; i++) {
+                for (int j = 1; j <= N; j++) {
+                    // i와 k 사이 크기 비교가 가능하고
+                    // k와 j 사이 크기 비교도 가능할 때
+                    if (num[i][k] != 0 && num[k][j] != 0) {
+                        num[i][j] = 1;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = null;
+        StringBuilder sb = new StringBuilder();
+
+        N = Integer.parseInt(br.readLine());
+        M = Integer.parseInt(br.readLine());
+
+        num = new int[N + 1][N + 1];
+
+        for (int m = 0; m < M; m++) {
+
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            // a > b
+            num[a][b] = 1;
+        }
+
+        floyd();
+
+        for (int i = 1; i <= N; i++) {
+            // i 번째 줄 검사
+            sb.append(count(i)).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+
+}

--- a/nana/week12/Main_14500_테트로미노.java
+++ b/nana/week12/Main_14500_테트로미노.java
@@ -1,0 +1,71 @@
+package study.week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_14500_테트로미노 {
+    private static int N, M, result;
+    private static int[][] paper;
+    private static boolean[][] isVisited;
+    private static int[][] delta = { { 1, 0 }, { 0, 1 }, { -1, 0 }, { 0, -1 } };
+
+    private static void dfs(int x, int y, int sum, int count) {
+
+        if (count == 4) {
+            result = Math.max(result, sum);
+            return;
+        }
+
+        for (int[] d : delta) {
+            int nx = x + d[0];
+            int ny = y + d[1];
+
+            if (nx < 0 || ny < 0 || nx >= N || ny >= M)
+                continue;
+            if (isVisited[nx][ny])
+                continue;
+
+            if (count == 2) {
+                // ㅏ, ㅓ, ㅗ, ㅜ 모양의 경우를 검사해야한다
+                isVisited[nx][ny] = true;
+                dfs(x, y, sum + paper[nx][ny], count + 1);
+                isVisited[nx][ny] = false;
+            }
+
+            isVisited[nx][ny] = true;
+            dfs(nx, ny, sum + paper[nx][ny], count + 1);
+            isVisited[nx][ny] = false;
+
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        paper = new int[N][M];
+        isVisited = new boolean[N][M];
+        result = 0;
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                paper[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                isVisited[i][j] = true;
+                dfs(i, j, paper[i][j], 1);
+                isVisited[i][j] = false;
+            }
+        }
+
+        System.out.println(result);
+    }
+}

--- a/nana/week12/Main_1764_듣보잡.java
+++ b/nana/week12/Main_1764_듣보잡.java
@@ -17,7 +17,7 @@ public class Main_1764_듣보잡 {
         // 들어본 적 없는 사람의 이름을 저장
         HashMap<String, Integer> map = new HashMap<>();
         // 듣도보도 못한 사람을 저장할 리스트
-        // Priory Queue를 선언해도 됨
+        // Priority Queue를 선언해도 됨
         List<String> result = new ArrayList<>();
 
         for(int i =0; i<N; i++){

--- a/nana/week12/Main_1764_듣보잡.java
+++ b/nana/week12/Main_1764_듣보잡.java
@@ -1,0 +1,46 @@
+package study.week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_1764_듣보잡 {
+    public static void main(String[] args) throws Exception{
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // 들어본 적 없는 사람의 이름을 저장
+        HashMap<String, Integer> map = new HashMap<>();
+        // 듣도보도 못한 사람을 저장할 리스트
+        // Priory Queue를 선언해도 됨
+        List<String> result = new ArrayList<>();
+
+        for(int i =0; i<N; i++){
+            map.put(br.readLine(), 1);
+        }
+
+
+        for(int i =0; i<M; i++){
+            String name = br.readLine();
+            // 보지 못한 사람이 들어본 적도 없는 사람이면 추가
+            if(map.containsKey(name)) {
+                result.add(name);
+            }
+        }
+
+        // 사전순 출력을 위한 리스트 정렬
+        Collections.sort(result);
+
+        sb.append(result.size()).append("\n");
+        for(String s:result){
+            sb.append(s).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}

--- a/nana/week12/Main_1764_듣보잡_2.java
+++ b/nana/week12/Main_1764_듣보잡_2.java
@@ -1,0 +1,42 @@
+package study.week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_1764_듣보잡_2 {
+    public static void main(String[] args) throws Exception{
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // 들어본 적 없는 사람의 이름을 저장할 set. 중복을 허용하지 않음.
+        HashSet<String> set = new HashSet<>();
+        List<String> result = new ArrayList<>();
+
+        for(int i =0; i<N; i++){
+            set.add(br.readLine());
+        }
+
+
+        for(int i =0; i<M; i++){
+            String name = br.readLine();
+            if(set.contains(name)) {
+                result.add(name);
+            }
+        }
+
+        Collections.sort(result);
+
+        sb.append(result.size()).append("\n");
+        for(String s:result){
+            sb.append(s).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}

--- a/nana/week12/Main_1967_트리의지름.java
+++ b/nana/week12/Main_1967_트리의지름.java
@@ -1,0 +1,82 @@
+package study.week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main_1967_트리의지름 {
+    private static int n, result, node; // 가장 먼 노드를 저장
+    private static List<Tree>[] tree;
+    private static boolean[] isVisited;
+
+    static class Tree {
+        int idx, weight;
+
+        // 연결된 곳과 가중치를 받아온다.
+        public Tree(int idx, int weight) {
+            this.idx = idx;
+            this.weight = weight;
+        }
+
+        @Override
+        public String toString() {
+            return "Tree [idx=" + idx + ", weight=" + weight + "]";
+        }
+
+    }
+
+    private static void dfs(int index, int dis) {
+        isVisited[index] = true;
+
+        if (result < dis) {
+            // 최댓값이면 result 값과 node의 위치 변경
+            result = dis;
+            node = index;
+        }
+        for (int i = 0; i < tree[index].size(); i++) {
+            if (!isVisited[tree[index].get(i).idx]) {
+                // 재귀호출 시, 현재 가리키는 값과 누적 가중치+현재 가중치 를 입력 받는다.
+                dfs(tree[index].get(i).idx, dis + tree[index].get(i).weight);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = null;
+
+        n = Integer.parseInt(br.readLine());
+
+        tree = new ArrayList[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            tree[i] = new ArrayList<>();
+        }
+
+        result = Integer.MIN_VALUE;
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            // 양방향에 가중치 입력
+            tree[a].add(new Tree(b, w));
+            tree[b].add(new Tree(a, w));
+        }
+
+        isVisited = new boolean[n + 1];
+        // 시작점부터 가장 먼 곳까지의 거리 구하기
+        dfs(1, 0);
+
+        isVisited = new boolean[n + 1];
+        // 가장 먼 곳에서 먼 곳 구하기
+        dfs(node, 0);
+
+        System.out.println(result);
+
+    }
+}

--- a/nana/week12/Main_7662_이중우선순위큐_2.java
+++ b/nana/week12/Main_7662_이중우선순위큐_2.java
@@ -1,0 +1,73 @@
+package study.week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.TreeMap;
+
+public class Main_7662_이중우선순위큐_2 {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine());
+
+        for (int tc = 1; tc <= T; tc++) {
+
+            int k = Integer.parseInt(br.readLine());
+
+            TreeMap<Integer, Integer> map = new TreeMap<>();
+
+            for (int i = 0; i < k; i++) {
+
+                st = new StringTokenizer(br.readLine());
+                String order = st.nextToken();
+                int num = Integer.parseInt(st.nextToken());
+
+                if (order.equals("I")) {
+                    // I 일 때 맵에 키값으로 없다면 num:1 을 넣음
+                    if (!map.containsKey(num))
+                        map.put(num, 1);
+                    else
+                        // 이미 존재하는 값이라면 num: value++를 넣음
+                        map.replace(num, map.get(num) + 1);
+                } else {
+
+                    // order 가 D지만 맵이 비어있다면 넘어감
+                    if(map.isEmpty()) continue;
+
+                    // num 이 1이면 가장 큰 값 -1 이면 가장 작은 값을 꺼냄
+                    if (num == 1) {
+                        // 맵의 가장 큰 값의 value가 1이라면 하나만 있는 값이므로
+                        // 마지막값을 모두 빼줌
+                        if (map.get(map.lastKey()) == 1)
+                            map.pollLastEntry();
+                        else
+                            // value가 1이 아니라면 값이 두 개 이상이므로
+                            // key는 건들지 않고 value만 하나 줄여준다
+                            map.replace(map.lastKey(), map.get(map.lastKey()) - 1);
+                    } else {
+                        // 위 방법과 동일하게 진행
+                        if (map.get(map.firstKey()) == 1)
+                            map.pollFirstEntry();
+                        else
+                            map.replace(map.firstKey(), map.get(map.firstKey()) - 1);
+                    }
+                }
+            }
+
+            if (map.isEmpty()) {
+                sb.append("EMPTY\n");
+            } else {
+                sb.append(map.lastKey() + " " + map.firstKey() + "\n");
+            }
+
+
+        }
+
+        System.out.println(sb);
+
+    }
+}


### PR DESCRIPTION
## 🔍 개요
+ close #31 

## ✔️ 문제 풀이 진행 사항
+ 백준_1764_듣보잡 - 완료
+ 백준_1967_트리의지름 - 완료
+ 백준_7662_이중우선순위큐 - 완료
+ 백준_10159_저울 - 완료
+ 백준_14500_테트로미노 - 완료

## 📝 문제 풀이 전략 및 실제 풀이 방법
**백준_1764_듣보잡**
Map의 키 값으로 입력을 받고, 두번째 입력 받는 이름이 이미 받은 값이라면 결과 리스트에 추가
사전순 출력을 위해 리스트 정렬 후, 리스트 사이즈와 리스트 출력

**백준_1967_트리의지름**
처음 풀었던 방식은 단순히 1부터 트리의 깊이를 재는 방식에 불과했다.. 
트리의 '지름' 이기 때문에 dfs를 두번 돌려야했다! 
양방향으로 트리에 가중치를 입력하고 두번의 dfs를 돌리면서 결과값을 최댓값으로 계속 갱신시켜줬다.

**백준_7662_이중우선순위큐**
TreeMap을 이용해서 풀 수 있었다. 키값이 중복이 안되기 때문에 같은 값이 여러개 들어오면 value를 이용해 개수를 세어줌
뺄 때도 마찬가지로 value가 2 이상이면 키를 빼지 않고 값만 줄여줬다

**백준_10159_저울**
플로이드와샬로 풀었으나 dfs도 가능
2차원 배열을 선언하고 행의 값보다 열의 값이 작을 때 해당 칸을 1로 만들어 준다
마지막에 각 행을 검사하여 알 수 없는 경우를 출력 

**백준_14500_테트로미노**
모두 4칸(깊이가 4)으로 이루어졌기 때문에 dfs로 풀었다
ㅏ ㅓ ㅗ ㅜ 모양인 경우를 확인하는 방법을 추가해야했는데 이 부분을 생각하는게 조금 힘들었음

## 🧐 참고 사항


## 📄 Reference
