### PR TITLE
12주차 문제 풀이

### DIFF
--- a/kkayoung/12Week/BOJ_10159_저울.java
+++ b/kkayoung/12Week/BOJ_10159_저울.java
@@ -1,0 +1,80 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static class Stuff {
+		int weight;
+		Stuff next;
+
+		Stuff(int weight, Stuff next) {
+			this.weight = weight;
+			this.next = null;
+		}
+	}
+
+	static Stuff[] lighter;   // 물건 i보다 가벼운 물건 연결리스트
+	static int[] cmpcnt;      // 비교 횟수 저장
+	static boolean[] visited;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+
+		int N = Integer.parseInt(br.readLine());
+		int M = Integer.parseInt(br.readLine());
+
+		lighter = new Stuff[N];
+		cmpcnt = new int[N];
+
+		for (int i = 0; i < N; i++) {
+			lighter[i] = new Stuff(-1, null); // dummy head
+		}
+
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int heavy = Integer.parseInt(st.nextToken()) - 1;
+			int light = Integer.parseInt(st.nextToken()) - 1;
+
+			Stuff newNode = new Stuff(light, null);
+			newNode.next = lighter[heavy].next; // dummy head 뒤에 newNode 추가
+			lighter[heavy].next = newNode;
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < N; i++) { // 모든 물건에 대해 dfs 탐색
+			visited = new boolean[N];
+			visited[i] = true;
+			if (lighter[i].next == null) // empty
+				continue;
+			dfs(i, i);
+		}
+		for (int i = 0; i < N; i++) {
+			sb.append((N - 1 - cmpcnt[i]) + "\n"); // (전체 물건 개수 - 1 - 물건 i와 비교한 물건 개수) 출력, 자기 자신과 비교하는 경우 제외시키기 위해 1 뺌
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+
+	}
+
+	static void dfs(int src, int n) {
+		if (lighter[n].next == null)
+			return;
+
+		for (Stuff tmp = lighter[n]; tmp != null; tmp = tmp.next) {
+			if (tmp.weight == -1 || visited[tmp.weight])
+				continue;
+			visited[tmp.weight] = true;
+			cmpcnt[src]++; // 물건 src와 물건 tmp.weight 비교함 -> 물건 cnt 비교 횟수 1 증가
+			cmpcnt[tmp.weight]++; // 물건 src와 물건 tmp.weight 비교함 -> 물건 tmp.weight 비교 횟수 1 증가
+			dfs(src, tmp.weight);
+		}
+	}
+}

--- a/kkayoung/12Week/BOJ_14500_테트로미노.java
+++ b/kkayoung/12Week/BOJ_14500_테트로미노.java
@@ -1,0 +1,69 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int N, M, answer;
+	static int[][] paper;
+	static int[][] dir = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+	static boolean[][] visited;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		paper = new int[N][M];
+		answer = Integer.MIN_VALUE;
+
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < M; j++) {
+				paper[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		visited = new boolean[N][M];
+		for (int r = 0; r < N; r++) { // (0,0)부터 (N,M) 까지 모든 칸에 5가지 테트로미노를 모두 배치해봄
+			for (int c = 0; c < M; c++) {
+				visited[r][c] = true;
+				solution(r, c, 1, paper[r][c]);
+				visited[r][c] = false;
+			}
+		}
+		bw.write(String.valueOf(answer));
+		bw.flush();
+		bw.close();
+	}
+
+	static void solution(int r, int c, int cnt, int sum) { // 행, 열, 선택 칸 개수, 점수
+		if (cnt == 4) { // 4칸 모두 선택 == 테트로미노 완성
+			answer = Math.max(answer, sum);
+			return;
+		}
+
+		for (int d = 0; d < 4; d++) {
+			int nr = r + dir[d][0];
+			int nc = c + dir[d][1];
+			if (nr < 0 || nr >= N || nc < 0 || nc >= M || visited[nr][nc])
+				continue;
+
+			visited[nr][nc] = true;
+			solution(nr, nc, cnt + 1, sum + paper[nr][nc]);
+			visited[nr][nc] = false;
+
+			if (cnt == 2) { // 2칸을 선택했다면 ㅗ,ㅏ,ㅓ,ㅜ 모양 테트로미노 만들 수 있다
+				visited[nr][nc] = true;
+				solution(r, c, cnt + 1, sum + paper[nr][nc]); // nr,nc로 이동하지 않음
+				visited[nr][nc] = false;
+			}
+
+		}
+	}
+}

--- a/kkayoung/12Week/BOJ_1764_듣보잡.java
+++ b/kkayoung/12Week/BOJ_1764_듣보잡.java
@@ -1,0 +1,36 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            StringBuilder sb = new StringBuilder();
+            int N = Integer.parseInt(st.nextToken());
+            int M = Integer.parseInt(st.nextToken());
+            Map<String, Integer> map = new HashMap<>(); // 이름, 등장횟수
+            List<String> nameList= new ArrayList<>();   // 듣도 보도 못한 사람 리스트
+            int answer = 0;
+            for (int i = 0; i < N; i++) {
+                map.put(br.readLine(), 1); // 듣도 못한 사람의 등장 횟수: 1
+            }
+            for (int i = 0; i < M; i++) {
+                String name = br.readLine(); // 보도 못한 사람 이름
+                int cnt = map.getOrDefault(name, 0);
+                if (cnt>0){ // map에 있던 사람이라면
+                    answer++;
+                    nameList.add(name); // 듣도 보도 못한 사람을 리스트에 추가
+                }
+            }
+            Collections.sort(nameList); // 정렬
+            sb.append(String.valueOf(answer)+"\n");
+            for (String name : nameList) {
+                sb.append(name + "\n");
+            }
+            out.write(sb.toString());
+            out.flush();
+            out.close();
+        }
+}

--- a/kkayoung/12Week/BOJ_1967_트리의지름.java
+++ b/kkayoung/12Week/BOJ_1967_트리의지름.java
@@ -1,0 +1,75 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main{
+    
+    static class Node{
+        int num, weight; // 노드 번호, 가중치
+        Node(int num, int weight){
+            this.num = num;
+            this.weight = weight;
+        
+        }
+    }
+    static boolean[] visited;
+    static int farNode; // 가장 먼 노드
+    static List<Node>[] adjList;
+    static int max;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(in.readLine());
+        adjList = new ArrayList[N+1];
+        for(int i=1;i<=N;i++){
+            adjList[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(in.readLine());
+            int parent = Integer.parseInt(st.nextToken());
+            int child = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+            adjList[parent].add(new Node(child,weight));
+            adjList[child].add(new Node(parent, weight));
+        }
+
+        // 1번 노드에서 가장 먼 노드 farNode 찾기
+        max = Integer.MIN_VALUE;
+        visited = new boolean[N+1];
+        dfs(1, 0);
+
+        // farNode번 노드에서 가장 먼 노드 찾기
+        max = Integer.MIN_VALUE;
+        visited = new boolean[N+1];
+        dfs(farNode, 0);
+
+        out.write(String.valueOf(max));
+        out.flush();
+        out.close();
+    }
+
+    static void dfs(int n, int weightSum){
+        visited[n] = true;
+        for(Node node:adjList[n]){
+            int num = node.num;
+            int weight = node.weight;
+            if(visited[num]==true) continue;
+            dfs(num,weightSum+weight);
+        }
+        if(weightSum>max) { // n번 노드를 방문하기까지의 가중치 합이 max보다 크다면 max 갱신
+            max = weightSum;
+            farNode = n;
+        }
+        // System.out.println("n: "+n+", weightSum: "+weightSum+", max: "+max);
+    }
+
+}

--- a/kkayoung/12Week/BOJ_7662_이중우선순위큐.java
+++ b/kkayoung/12Week/BOJ_7662_이중우선순위큐.java
@@ -1,0 +1,81 @@
+import static java.lang.Integer.parseInt;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class practicejava {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws Exception {
+		int T = parseInt(br.readLine());
+		for (int tc = 1; tc <= T; tc++) {
+			int k = parseInt(br.readLine());
+			solve(k);
+		}
+		System.out.println(sb);
+	}
+
+	public static void solve(int k) throws Exception {
+		PriorityQueue<Integer> minQ = new PriorityQueue<>(); // 최소힙
+		PriorityQueue<Integer> maxQ = new PriorityQueue<Integer>((x, y) -> Integer.compare(y, x)); // 최대힙
+		Map<Integer, Integer> syncMap = new HashMap<>(); // (숫자, 개수) 
+
+		for (int i = 0; i < k; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			char cmd = st.nextToken().charAt(0);
+			int value = Integer.parseInt(st.nextToken());
+			if (cmd == 'D') {
+				// D 1: 최댓값 제거
+				if (value == 1) {
+					// 이미 제거된 원소를 최대힙에서 제거
+					while (!maxQ.isEmpty() && syncMap.get(maxQ.peek()) <= 0) {
+						maxQ.poll();
+					}
+					if (!maxQ.isEmpty()) {
+						int elem = maxQ.poll(); // 최댓값 제거
+						syncMap.put(elem, syncMap.get(elem) - 1); // elem 개수 1 감소
+					}
+				} else if (value == -1) { // D -1: 최솟값 제거
+					while (!minQ.isEmpty() && syncMap.get(minQ.peek()) <= 0) {
+						minQ.poll();
+					}
+					if (!minQ.isEmpty()) {
+						int elem = minQ.poll(); // 최솟값 제거
+						syncMap.put(elem, syncMap.get(elem) - 1); // elem 개수 1 감소
+					}
+				}
+			} else if (cmd == 'I') { // I n: 정수 n 추가
+				int newCount = syncMap.getOrDefault(value, 0);
+				syncMap.put(value, newCount + 1);
+				minQ.add(value);
+				maxQ.add(value);
+			}
+		}
+
+    int cnt = 0; // 큐에 있는 숫자의 개수
+		int min = 0, max=0;
+        while(!minQ.isEmpty()){
+            int num = minQ.poll();
+            int numCnt = syncMap.get(num);
+            if(numCnt>0){
+                min = num;
+                cnt++;
+                break;
+            }
+        }
+        while(!maxQ.isEmpty()){
+            int num = maxQ.poll();
+            int numCnt = syncMap.get(num);
+            if(numCnt>0){
+                max = num;
+                break;
+            }
+        }
+		if (cnt==0) sb.append("EMPTY\n");
+		else sb.append(String.format("%d %d\n", max, min));
+	}
+}


### PR DESCRIPTION
## 🔍 개요
- close #33  

## ✔️ 문제 풀이 진행 사항
+ 문제 1 백준_10159_저울 - 완료
+ 문제 2 백준_14500_테트로미노 - 완료
+ 문제 3 백준_1967_트리의 지름 - 완료
+ 문제 4 백준 듣보잡 - 완료
+ 문제 5 백준 이중 우선 순위 큐 - 완료


## 📝 문제 풀이 전략 및 실제 풀이 방법

저울 : 연결리스트 + dfs. 각 물건과 비교한 물건의 개수를 저장하는 배열을 만든다. 전체 물건 개수에서 비교한 물건 수를 뺀다.

테트로미노 : dfs. 테트로미노는 블록 4개를 사용하면 만들 수 있기 때문에 깊이 4까지만 탐색. 모든 좌표에서 dfs를 수행함.

트리의 지름 : dfs. 1번 노드와 가장 먼 노드 번호 f 탐색. f번 노드와 가장 먼 노드까지의 가중치 합을 출력.

듣보잡 : hashmap, list. 듣도 못한 사람을 map에 넣음. 보도 못한 사람이 map에 이미 포함되어 있다면 리스트에 추가함. 리스트 정렬하고 출력

이중 우선 순위 큐 : priorityQueue, map. 최대 힙, 최소 힙을 만든다. 숫자와 숫자 개수를 저장할 map을 만듦. 최대, 최소 힙에서 값을 제거할 때 map과 동기화해준다.

## 🧐 참고 사항


## 📄 Reference

