### PR TITLE
14주차 문제 풀이

### DIFF
--- a/kkayoung/14Week/BOJ_1753_최단경로.java
+++ b/kkayoung/14Week/BOJ_1753_최단경로.java
@@ -1,0 +1,78 @@
+// https://www.acmicpc.net/problem/1753
+// 우선순위 큐를 사용한 다익스트라
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	static int[] dist;
+	static boolean[] visited; 
+	static int INF = Integer.MAX_VALUE;
+	static class Edge implements Comparable<Edge>{
+		int v, weight;
+		Edge(int v, int weight){
+			this.v = v;
+			this.weight = weight;
+		}
+		@Override
+		public int compareTo(Edge o){ // 가중치 오름차순 정렬
+			return Integer.compare(this.weight, o.weight);
+		}
+	}
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		int V = Integer.parseInt(st.nextToken());// 정점 수
+		int E = Integer.parseInt(st.nextToken());// 간선 수
+		int K = Integer.parseInt(br.readLine()); // 시작
+
+		PriorityQueue<Edge> pq = new PriorityQueue<>(); // K번 정점에서 가장 가까운 정점부터 방문해야 하기 때문에, 가중치 기준으로 정렬한 우선순위 큐가 필요
+		List<Edge>[] adjList = new List[V+1]; // 인접리스트
+		for(int i=1;i<=V;i++) adjList[i]=new ArrayList<>();
+		visited = new boolean[V+1]; // 방문
+		dist = new int[V+1];   // 시작점에서부터 각 노드까지의 최단 거리 저장 
+		Arrays.fill(dist,INF); // INF(노드에 도달할 수 없음)로 초기화
+		dist[K] = 0; // 시작점->시작점 거리는 0
+
+		for(int i=0;i<E;i++){
+			st = new StringTokenizer(br.readLine());
+			int u = Integer.parseInt(st.nextToken());
+			int v = Integer.parseInt(st.nextToken());
+			int w = Integer.parseInt(st.nextToken());
+			adjList[u].add(new Edge(v,w));
+		}
+
+		// dijkstra
+		pq.offer(new Edge(K,0));
+		while(!pq.isEmpty()){
+			Edge e = pq.poll();
+			int now = e.v;
+			
+			if(visited[now]==true) continue;
+			visited[now] = true;
+
+			for(Edge link:adjList[now]){
+				if(dist[now]+link.weight < dist[link.v]){ //  K, now번 노드 사이 거리 + now, link.v번 노드 사이 거리 < K, link.v번 노드 사이 거리
+					dist[link.v] = dist[now]+link.weight;
+					pq.offer(new Edge(link.v,dist[link.v])); // K번 노드에서 link.v번 노드까지의 거리를 우선순위 큐에 넣음
+				}
+			}
+			// System.out.println(Arrays.toString(dist));
+		} 
+				
+		// output
+		StringBuilder sb = new StringBuilder();
+		for(int i=1;i<=V;i++){
+			int d = dist[i];
+			if(d==Integer.MAX_VALUE) sb.append("INF\n");
+			else sb.append(d+"\n");
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		
+	}
+}

--- a/kkayoung/14Week/BOJ_17836_공주님을구해라.java
+++ b/kkayoung/14Week/BOJ_17836_공주님을구해라.java
@@ -1,0 +1,87 @@
+// https://www.acmicpc.net/problem/17836
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	static final int BLANK = 0;
+	static final int WALL = 1;
+	static final int GRAM = 2;
+	static int N, M, T;
+	static int[][] map; // 지도
+	static int[][] dir = {{-1,0},{0,1},{1,0},{0,-1}}; // u r d l
+	static boolean[][][] visited; // 방문 여부
+	static int time = Integer.MAX_VALUE; 
+	static Queue<int[]> q;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		q = new ArrayDeque<>();
+		
+		// input
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken()); // 성 크기
+		M = Integer.parseInt(st.nextToken()); // 성 크기
+		T = Integer.parseInt(st.nextToken()); // 시간제한
+		map = new int[N][M];
+		visited = new boolean[N][M][2];
+
+		for(int i=0;i<N;i++){
+			st = new StringTokenizer(br.readLine());
+			for(int j=0;j<M;j++){
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+    
+		// 공주에게 도달할 수 있는 최단 시간 계산
+		rescue();
+
+		// output
+		String answer = (time==Integer.MAX_VALUE) ? "Fail":String.valueOf(time);
+		bw.write(answer);
+		bw.flush();
+		bw.close();
+		
+	}
+
+	static void rescue(){
+		q.offer(new int[]{0,0,0,0}); // r, c, time, gram 보유 flag
+		visited[0][0][0] = true; // 그람을 보유하지 않았을 때 (0,0) 방문
+
+		while(!q.isEmpty()){
+			int[] now = q.poll();
+			int r = now[0]; // row
+			int c = now[1]; // col
+			int t = now[2]; // 시작점에서부터 (r,c)까지 도달하는 데 소요한 시간
+			int hasGRAM = now[3]; // 0이면 그람을 가지고 있지 않음
+			if(r==N-1 && c==M-1 && t<=T){ // 공주에게 도달함
+				time = Math.min(t,time);
+			}
+			if(t>time) continue; // 현재 구한 최단 시간보다 더 오래 걸리면 더 이상 탐색하지 않음
+
+			for(int d=0;d<4;d++){
+				int nr = r+dir[d][0];
+				int nc = c+dir[d][1];
+				if(0<=nr && nr<N && 0<=nc && nc<M && visited[nr][nc][hasGRAM]==false){
+					if (hasGRAM==0){ // 현재 그람 미보유
+						if(map[nr][nc]==GRAM){ // 다음 칸이 그람이라면
+							q.offer(new int[]{nr,nc,now[2]+1,1}); // flag on
+							visited[nr][nc][1] = true; // gram을 가진 상태에서 (nr,nc)를 방문
+						}
+						else if(map[nr][nc]==BLANK){ // 다음 칸이 빈칸
+							q.offer(new int[]{nr,nc,now[2]+1,0});
+							visited[nr][nc][0] = true; // gram을 가지지 않은 상태에서 (nr,nc)를 방문
+						}
+					}
+					else { // 현재 그람 보유 -> 벽, 빈칸 상관없이 방문 가능함
+						map[nr][nc] = BLANK;
+						q.offer(new int[]{nr,nc,now[2]+1,1});
+						visited[nr][nc][1] = true;
+					}
+				}
+			}
+		}
+	}
+}

--- a/kkayoung/14Week/BOJ_19583_싸이버개강총회.java
+++ b/kkayoung/14Week/BOJ_19583_싸이버개강총회.java
@@ -1,0 +1,55 @@
+// https://www.acmicpc.net/problem/19583
+// 맵 사용(이름, 출석현황)
+// 입실하면 출석현황을 1로 설정
+// 입실한 사람 중에서 퇴실한 사람의 출석현황을 2로 설정
+// 출석현황이 2인 사람 수를 출력
+import java.io.*;
+import java.util.*;
+
+public class Main{
+
+	static Map<String, Integer> attendance;
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		String S = st.nextToken();
+		String E = st.nextToken();
+		String Q = st.nextToken();
+
+		attendance = new HashMap<>();
+		String line = null;
+		while((line=(br.readLine()))!=null){
+			String[] splited= line.split(" ");
+			if(splited.length<2) break;
+			String time = splited[0];
+			String nickname = splited[1];
+
+			// time <= S 이면 입실체크
+			if(time.compareTo(S)<=0){
+				attendance.put(nickname, 1);
+			}
+			// E <= time <= Q 이면 퇴실체크
+			if(E.compareTo(time)<=0 && time.compareTo(Q)<=0){
+				int status = attendance.getOrDefault(nickname, -1);
+				if(status != -1 && status != 2){
+					attendance.put(nickname,2);
+				}
+			}
+		}
+
+		int answer = 0;
+		Collection<Integer> val = attendance.values();
+		for(int v:val){
+			if(v==2) answer++;
+		}
+				
+		// output
+		bw.write(String.valueOf(answer));
+		bw.flush();
+		bw.close();
+		
+	}
+}

--- a/kkayoung/14Week/BOJ_2667_단지번호붙이기.java
+++ b/kkayoung/14Week/BOJ_2667_단지번호붙이기.java
@@ -1,0 +1,76 @@
+// https://www.acmicpc.net/problem/2667
+// bfs, 안전영역 문제와 비슷한 방법으로 해결함
+// visited 배열 대신 방문한 좌표의 값을 BLANK로 변경해서 방문 여부 체크함 
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	static final int BLANK = 0;
+	static int[][] dir = {{-1,0},{1,0},{0,-1},{0,1}};
+	static List<Integer> answerList;
+	static int[][] map;
+	static int N;
+	static Queue<int[]> q;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		answerList = new ArrayList<>();
+		q = new ArrayDeque<>();
+		StringBuilder sb = new StringBuilder();
+
+		// input
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		for(int i=0;i<N;i++){
+			String line = br.readLine();
+			for(int j=0;j<N;j++){
+				map[i][j] = line.charAt(j)-'0';
+			}
+		}
+
+		// bfs
+		for(int i=0;i<N;i++){
+			for(int j=0;j<N;j++){
+				if(map[i][j]==BLANK) continue;
+				answerList.add(find(i,j));
+			}
+		}
+
+		// output
+        Collections.sort(answerList);
+		sb.append(answerList.size()+"\n");
+		for(int cnt:answerList){
+			sb.append(cnt+"\n");
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		
+	}
+	static int find(int r, int c){
+    // (r,c)에서부터 bfs 탐색
+    // (r,c)와 연결된 좌표들 중 값이 1인 칸의 개수 리턴
+		map[r][c] = BLANK; // visited
+		q.offer(new int[]{r,c});
+		int result = 1;
+		
+		while(!q.isEmpty()){
+			int[] now = q.poll();
+			r = now[0];
+			c = now[1];
+			for(int d=0;d<4;d++){
+				int nr = r+dir[d][0];
+				int nc = c+dir[d][1];
+				if(0<=nr && nr<N && 0<=nc && nc<N && map[nr][nc]!=BLANK){
+					q.offer(new int[]{nr,nc});
+					map[nr][nc] = BLANK;
+					result++;
+				}
+			}
+		}
+		return result;
+	}
+}

--- a/kkayoung/14Week/PG_개인정보수집유효기간.java
+++ b/kkayoung/14Week/PG_개인정보수집유효기간.java
@@ -1,0 +1,59 @@
+// https://school.programmers.co.kr/learn/courses/30/lessons/150370
+import java.util.*;
+
+class Solution {
+    public int[] solution(String today, String[] terms, String[] privacies) {
+        
+        List<Integer> answer = new ArrayList<>();
+
+        // 약관 조건
+        Map<Character, Integer> term = new HashMap<>(); // (약관, 약관 기간)
+        for(String t:terms){
+            String[] splitedTerm = t.split(" ");
+            term.put(splitedTerm[0].charAt(0), Integer.parseInt(splitedTerm[1]));
+        }       
+
+        // 개인정보와 약관
+        int idx=1;
+        for(String privacy:privacies){
+            String[] date_term = privacy.split(" "); // 날짜, 약관 분리
+            int[] privacy_ymd = convert(date_term[0]);
+            char termType = date_term[1].charAt(0); // 약관 종류
+            if(destroy(today,calExpiredDate(privacy_ymd, term.get(termType)))){
+                answer.add(idx);
+            }
+            idx++;
+        }
+    
+        return answer.stream().mapToInt(i -> i).toArray(); // Integer list -> int array
+    }
+    
+    public boolean destroy(String today, String expiredDate){
+        // 만기 시작 날짜(expiredDate)가 오늘(today)보다 작거나 같으면 파기해야함. return true
+        // 그렇지 않으면 return false
+        return expiredDate.compareTo(today)<=0;
+    }
+    public String calExpiredDate(int[] ymd, int addedMonth){ 
+        // yyyy.mm.dd로부터 addedMonth 뒤 날짜 계산
+        int addedYear = addedMonth/12;
+        addedMonth %= 12;
+        ymd[1] += addedMonth;
+        
+        if (ymd[1]>12){
+            ymd[1] -= 12;
+            ymd[0] += 1;
+        }
+        ymd[0] += addedYear;
+        return String.format("%d.%02d.%02d",ymd[0],ymd[1],ymd[2]);        
+    }
+    
+    public int[] convert(String date){ 
+        // "yyyy.mm.dd" -> {yyyy,mm,dd}
+        int[] result = new int[3];
+        String[] ymd = date.split("\\.");
+        result[0] = Integer.parseInt(ymd[0]);
+        result[1] = Integer.parseInt(ymd[1]);
+        result[2] = Integer.parseInt(ymd[2]);
+        return result;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
+ #54 

## ✔️ 문제 풀이 진행 사항
+ (박나린) 백준_1753_최단경로 - 완료
+ (김영후) 백준_2667_단지번호붙이기 - 완료
+ (김동우) 백준_17836_공주님을 구해라! - 완료
+ (양윤모) 백준_19583_싸이버개강총회 - 완료
+ (강애리) 프로그래머스_개인정보 수집 유효기간 - 완료

## 📝 문제 풀이 전략 및 실제 풀이 방법
**백준_1753_최단경로**
우선순위 큐를 활용한 다익스트라 알고리즘을 구현함
시작점에서부터 각 노드까지의 최단 거리를 저장하는 dist 배열을 만들고 INF 값으로 초기화한다.
노드들의 연결 정보를 저장할 인접리스트 adjList를 만듦.
시작점(K번)에서부터 가장 가까운 정점부터 방문해야 하기 때문에 우선순위 큐를 만듦
우선순위 큐에 (정점 번호 v, 시작점K 부터 v까지의 거리) 형태로 저장한다.
시작점에서 가장 가까운 정점 u부터 방문하면서, u와 연결된 정점들과 시작점 사이 거리를 계산하면서 dist 배열을 갱신한다

**백준_2667_단지번호붙이기**
1. 2차원 배열을 순회하면서 좌표 값이 1이라면 그 좌표부터 bfs를 수행하며 값이 1인 칸의 개수를 계산한 후 리스트에 넣음
2. 리스트 정렬
3. 리스트 크기와 리스트 내용을 순서대로 출력
1주차 안전영역과 비슷한 것 같다.

**백준_17836_공주님을 구해라!**
bfs. visited 배열을 3차원으로 선언하여 (r,c)를 방문할 때의 gram 보유 상태도 함께 저장함
gram을 가지고 있는 경우,  가지고 있지 않은 경우를 구분함
gram을 가지고 있는 경우 다음 칸이 무엇이든 방문함
gram을 가지고 있지 않은 경우 gram칸 또는 빈 칸만 방문함

**백준_19583_싸이버개강총회**
맵 사용(이름, 출석현황)
한 줄을 입력받고, " "를 기준으로 split을 했을 때 나뉜 문자열의 개수가 2보다 작다면 더 이상 입력을 받지 않는다.
compareTo 함수를 이용해서 입실, 퇴실, 스트리밍 종료 시간과 로그 시간을 비교했다.
1. 입실하면 출석현황을 1로 설정
2. 입실한 사람 중에서 퇴실한 사람의 출석현황을 2로 설정
3. 출석현황이 2인 사람 수를 출력

**프로그래머스_개인정보 수집 유효기간**
구현 문제. 약관 타입에 따른 약관 기간은 Map을 사용하여 저장함
String 형태의 개인정보 수집 기간을 int[]로 변환한 후에 만기 시작 날짜를 계산하고 다시 String으로 리턴했다.
compareTo로 만기 시작 날짜와 오늘 날짜를 비교해서 (만기 시작 날짜<=오늘 날짜)일 때 answer 리스트에 추가했다.
약관 기간이 12보다 작거나 같다고 생각해서 틀렸었다.


## 🧐 참고 사항
**백준_17836_공주님을 구해라!**
유사한 문제: [백준 2206번: 벽 부수고 이동하기](https://www.acmicpc.net/problem/2206)

## 📄 Reference
**프로그래머스_개인정보 수집 유효기간**
[[Java] Integer ArrayList을 int 배열로 변환 방법](https://velog.io/@deannn/Java-int%ED%98%95-ArrayList-%EB%B0%B0%EC%97%B4-%EB%B3%80%ED%99%98)
[[Java] 문자열 마침표(dot)로 구분하여 자르기(split)](https://hianna.tistory.com/618)
[[Java] compareTo()사용법.문자열/숫자 비교](https://doitdoik.tistory.com/92)