### PR TITLE
김동우 14주차

### DIFF
--- a/kdw999/14Week/백준_1753_최단경로.java
+++ b/kdw999/14Week/백준_1753_최단경로.java
@@ -1,0 +1,88 @@
+package Week14;
+
+import java.util.*;
+import java.io.*;
+
+class Node implements Comparable<Node> {
+	int end;
+	int weight;
+	
+	public Node(int end, int weight) {
+		this.end = end;
+		this.weight = weight;
+	}
+
+	@Override
+	public int compareTo(Node o) {
+		return this.weight - o.weight;
+	}
+}
+
+public class 백준_1753_최단경로 {
+	
+	static int V;
+	static int E;
+	static int K;
+	static List<Node>[] adjList;
+	static int[] dist;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		
+		V = Integer.parseInt(st.nextToken()); // 정점
+		E = Integer.parseInt(st.nextToken()); // 간선
+		
+		adjList = new ArrayList[V+1];
+		dist = new int[V+1];
+		for(int i=1; i<=V; i++) dist[i] = Integer.MAX_VALUE;
+		
+		K = Integer.parseInt(br.readLine()); // 시작 정점
+		
+		for(int i=1; i<=V; i++) adjList[i] = new ArrayList<>();
+		
+		for(int i=1; i<=E; i++) {
+			
+			st = new StringTokenizer(br.readLine());
+			
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			int weight = Integer.parseInt(st.nextToken());
+			
+			adjList[from].add(new Node(to, weight));
+		}
+		
+		dijk(K);
+		
+		for(int i=1; i<=V; i++) {
+			if(dist[i] == Integer.MAX_VALUE) sb.append("INF\n");
+			else sb.append(dist[i]+"\n");
+		}
+		System.out.println(sb);
+		
+	} // main
+	
+	public static void dijk(int start) {
+		PriorityQueue<Node> pq = new PriorityQueue<>(); // 가중치 순으로 나열하기 위함
+		
+		boolean[] visit = new boolean[V+1];
+		pq.offer(new Node(start, 0));
+		dist[start] = 0; // 자기자신은 0
+		
+        while(!pq.isEmpty()) {
+        	Node curNode = pq.poll();
+        	int cur = curNode.end;
+        	
+        	if(visit[cur] == true) continue;
+        	visit[cur] = true;
+        	
+        	for(Node node : adjList[cur]) {
+        		if(dist[node.end] > dist[cur] + node.weight) {
+        			dist[node.end] = dist[cur] + node.weight;
+        			pq.add(new Node(node.end, dist[node.end]));
+        		}
+        	}
+        }
+	}
+}

--- a/kdw999/14Week/백준_17836_공주님을구해라.java
+++ b/kdw999/14Week/백준_17836_공주님을구해라.java
@@ -1,0 +1,94 @@
+package Week14;
+
+import java.util.*;
+import java.io.*;
+
+class Pos {
+	int r;
+	int c;
+	int dist;
+	
+	public Pos(int r, int c, int dist) {
+		this.r = r;
+		this.c = c;
+		this.dist = dist;
+	}
+}
+
+public class 백준_17836_공주님을구해라 {
+	
+	static int[] dr = {1, 0, 0, -1};
+	static int[] dc = {0, 1, -1, 0};
+	static int[][] map;
+	static boolean[][] visited;
+	static int N, M, T;
+	static int arriveTime = Integer.MAX_VALUE;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+	    N = Integer.parseInt(st.nextToken()); // 행
+	    M = Integer.parseInt(st.nextToken()); // 열
+	    T = Integer.parseInt(st.nextToken()); // 시간
+	    
+	    map = new int[N+1][M+1];
+	    visited = new boolean[N+1][M+1];
+	    
+	    for(int i=1; i<=N; i++) {
+	    	st = new StringTokenizer(br.readLine());
+	    	for(int j=1; j<=M; j++) {
+	    		map[i][j] = Integer.parseInt(st.nextToken());
+	    	}
+	    }
+	    
+	    bfs();
+	    
+	    if(arriveTime > T) System.out.println("Fail");
+	    else System.out.println(arriveTime);
+
+	}// main
+	
+	public static void bfs() {
+		
+		Queue<Pos> q = new ArrayDeque<>();
+		q.offer(new Pos(1, 1, 0));
+		visited[1][1] = true;
+		
+		while(!q.isEmpty()) {
+			
+			Pos p = q.poll();
+			
+			// 현재 칸에 성검 그람을 찾았다면 현재 지점에서 도착 지점까지의 거리 재기
+			if(map[p.r][p.c] == 2) {
+				
+				arriveTime = Math.abs(N-p.r) + Math.abs(M-p.c); // 도착점까지 남은 거리
+				arriveTime += p.dist; // 검 만나기 전까지의 거리
+				
+			}
+			
+			// 검 없이 공주 만나면
+			if(p.r == N && p.c == M) {
+				visited[p.r][p.c]= true;
+				
+				if(arriveTime > p.dist) arriveTime = p.dist; // 이전 도착시간 보다 현재 도착시간이 더 빠르다면
+				break;
+			}
+			
+			// 4방 탐색
+			for(int i=0; i<4; i++) {
+				
+				int nr = p.r + dr[i];
+				int nc = p.c + dc[i];
+				
+					if(nr < 1 || nr > N || nc < 1 || nc > M 
+							|| visited[nr][nc] || map[nr][nc] == 1) continue;
+					
+					visited[nr][nc] = true;
+					q.offer(new Pos(nr, nc, p.dist+1));
+			}
+			
+			
+		}
+	}
+}

--- a/kdw999/14Week/백준_19583_싸이버개강총회.java
+++ b/kdw999/14Week/백준_19583_싸이버개강총회.java
@@ -1,0 +1,65 @@
+package Week14;
+
+import java.util.*;
+import java.io.*;
+
+public class 백준_19583_싸이버개강총회 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		String initTime[] = br.readLine().split(" "); // 개총 시작시간, 개총 종료시간, 개총 스트리밍 종료시간
+		
+		String[] startTimeDiv = initTime[0].split(":");
+		String startTimeStr = startTimeDiv[0] + startTimeDiv[1]; // 22 00을 더해서 2200 자체로 만들기 위함
+		int startTime = Integer.parseInt(startTimeStr); // 2200을 정수화
+		
+		String[] EndTimeDiv = initTime[1].split(":");
+		String EndTimeStr = EndTimeDiv[0] + EndTimeDiv[1]; 
+		int EndTime = Integer.parseInt(EndTimeStr); 
+		
+		String[] StreamEndTimeDiv = initTime[2].split(":");
+		String StreamEndTimeStr = StreamEndTimeDiv[0] + StreamEndTimeDiv[1]; 
+		int StreamEndTime = Integer.parseInt(StreamEndTimeStr); 
+		
+//		System.out.println(startTime+" / " + EndTime + " / " + StreamEndTime);
+		
+		Map<String, Boolean> checkBefore = new HashMap<>();
+		Map<String, Boolean> checkAfter = new HashMap<>();
+		Set<String> set = new HashSet<>();
+		
+		String str;
+		while( (str = br.readLine()) != null ) {
+			String[] chatAndId = str.split(" "); // 채팅 시간, 채팅 입력자
+			
+			String[] chatTimeDiv = chatAndId[0].split(":");
+			String chatTimeStr = chatTimeDiv[0] + chatTimeDiv[1];
+			int chatTime = Integer.parseInt(chatTimeStr); // 채팅 시간
+			String chatId = chatAndId[1]; // 채팅 아이디
+			
+//			System.out.println(chatTime+ " / "+ chatId);
+			set.add(chatId);
+			
+			// 채팅 시간이 개총 시작시간 전 [시작 시간 포함]
+			if(chatTime <= startTime) {
+				checkBefore.put(chatId, true);
+			}
+			
+			// 채팅 시간이 개총 종료 시간 ~ 스트리밍 종료 시간
+			else if(EndTime <= chatTime && chatTime <= StreamEndTime) {
+				checkAfter.put(chatId, true);
+			}
+			
+		}
+		
+		int cnt=0;
+			
+			for(String id : set) {
+				
+				if(checkBefore.get(id) != null && checkBefore.get(id) &&
+					checkAfter.get(id) != null && checkAfter.get(id)) {
+					cnt++;
+				}
+		}
+			System.out.println(cnt);
+	}
+}

--- a/kdw999/14Week/백준_2667_단지번호붙이기.java
+++ b/kdw999/14Week/백준_2667_단지번호붙이기.java
@@ -1,0 +1,89 @@
+import java.util.*;
+import java.io.*;
+
+class Pos{
+	int r;
+	int c;
+	
+	public Pos(int r, int c) {
+		this.r = r;
+		this.c = c;
+	}
+}
+
+public class Main {
+	
+	static char[][] map; // 아파트 맵
+	static boolean[][] visited; // 방문한 단지 체크
+	static int[] dr = {1, -1, 0, 0};
+	static int[] dc = {0, 0, -1, 1};
+	static int N;
+	static int cnt;
+	static int cntApt;
+	static List<Integer> house; 
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		N = Integer.parseInt(br.readLine()); // 맵 크기
+		
+		map = new char[N][N];
+		visited = new boolean[N][N];
+		cnt = 0;
+	
+		for(int i=0; i<N; i++) {
+			String str = br.readLine();
+			for(int j=0; j<N; j++) {
+				map[i][j] = str.charAt(j);
+			}
+		}
+		
+		house = new ArrayList<>();
+		
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<N; j++) {
+				if(!visited[i][j] && map[i][j] == '1') {
+					cntApt=1;
+					bfs(i,j);
+				}
+			}
+		}
+		
+		System.out.println(house.size());
+		Collections.sort(house); 
+		
+		for(int n : house) System.out.println(n);
+		
+	} // main
+	
+	public static void bfs(int r, int c) {
+		
+		Queue<Pos> q = new ArrayDeque<>();
+		
+		q.offer(new Pos(r, c));
+		visited[r][c] = true;
+		
+		while(!q.isEmpty()) {
+			
+			Pos p = q.poll();
+			
+			for(int i=0; i<4; i++) {
+				int nr = p.r + dr[i];
+				int nc = p.c + dc[i];
+				
+				// 범위 벗어나면
+				if(nr < 0 || nr>=N || nc < 0 || nc >= N || visited[nr][nc]) continue;
+				
+				// 아파트 단지라면
+				if(map[nr][nc] == '1') {
+					cntApt++;
+					q.offer(new Pos(nr, nc));
+					visited[nr][nc] = true;
+				}
+			}
+		}
+		
+		house.add(cntApt);
+		cnt++;
+	}
+}

--- a/kdw999/14Week/프로그래머스_개인정보 수집기간 풀이 2개.md
+++ b/kdw999/14Week/프로그래머스_개인정보 수집기간 풀이 2개.md
@@ -1,0 +1,148 @@
+한 달은 28일 월 * 28
+일 년은 12개월 연 * 12 * 28
+
+월 * 28 + 연 * 12 * 28 + 일 -> 일수로 만들어서 숫자비교
+
+``` java
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class Solution {
+	public List<Integer> solution(String today, String[] terms, String[] privacies) {
+		List<Integer> answer = new ArrayList<>(); // 가변 크기의 List
+		Map<String, Integer> termMap = new HashMap<>();
+		int date = getDate(today); // 날짜를 연, 월, 일로 나누어주고 전부 일로 합산해서 int로 돌려주는 메서드
+
+		for (String s : terms) {
+			String[] term = s.split(" "); // 저장유형과 저장기간을 분리
+			termMap.put(term[0], Integer.parseInt(term[1])); // 저장유형에 저장기간 삽입
+		}
+		System.out.println(termMap);
+		for (int i = 0; i < privacies.length; i++) {
+			String[] privacy = privacies[i].split(" "); // 보관 시작날짜와 저장유형을 분리
+
+			
+			if (getDate(privacy[0]) + (termMap.get(privacy[1]) * 28) <= date) { // 보관 시작날짜 총 일수 + 유형별 보관기간의 일수 <= 현재 날짜의 총 일수 
+				answer.add(i + 1);
+			}
+		}
+		return answer; 
+	}
+
+	private int getDate(String today) {
+		String[] date = today.split("\\."); // .을 구분자로 쓰려면 [.] or \\. 사용
+		int year = Integer.parseInt(date[0]);
+		int month = Integer.parseInt(date[1]);
+		int day = Integer.parseInt(date[2]);
+		return (year * 12 * 28) + (month * 28) + day; // year과 month를 전부 day와 똑같은 수치로 만들어주고 리턴
+	}
+}
+
+```
+
+테케 1개 틀린 풀이, 뭐가 문젠지 모르겠다
+``` java 
+package algorhitm;
+
+import java.util.*;
+import java.io.*;
+
+
+public class Main {
+	
+	static Map<String, Integer> termsMap;
+	
+	public static void main(String[] args) throws IOException {
+		
+		String today = "2020.01.01";
+		String[] terms = {"Z 3", "D 5"};
+		String[] privacies = {"2019.01.01 D", "2019.11.15 Z", "2019.08.02 D", "2019.07.01 D", "2018.12.28 Z"};
+	
+		solution(today, terms, privacies);
+	}
+	
+	// 약관 종류만큼 날짜를 더한 후 현재 날짜보다 이전이라면 약관 끝, 이후라면 약관 유지
+	 public static List<Integer> solution(String today, String[] terms, String[] privacies) {
+	 
+		 String[] todayDiv = today.split("\\."); // 2022.05.19 .으로 짜르기
+		 
+		 String todayDivSum = todayDiv[0] + todayDiv[1] + todayDiv[2]; // 20220519 문자열
+		 int todayInt = Integer.parseInt(todayDivSum); // 20220519 정수, 이거 전후로 약관 기간 판단
+		 
+		 List<Integer> answer = new ArrayList<>();
+		 
+		 termsMap = new HashMap<>();
+		 for(int i=0; i<terms.length; i++) {
+			 // terms의 타입과 기간을 Map에 넣기
+			 String[] termsDiv = terms[i].split(" ");
+			 String type = termsDiv[0];
+			 int duration = Integer.parseInt(termsDiv[1]);
+			 
+			 termsMap.put(type, duration);
+		 }
+		 
+		 for(int i=0; i<privacies.length; i++) {
+			 
+			 String[] privaciesDateAndType = privacies[i].split(" "); // 2021.05.02 A 날짜와 타입 짜르기
+			 String[] privaciesDateDiv = privaciesDateAndType[0].split("\\."); // 2021.05.02 연월일 짜르기
+			 
+			 String year = privaciesDateDiv[0];
+			 String month = privaciesDateDiv[1];
+			 String day = privaciesDateDiv[2];
+			 String type = privaciesDateAndType[1];
+			 
+			 int result = calDate(year, month, day, type);
+			 
+			 // 약관 유지
+//			 System.out.println(result + " / "+todayInt);
+			 if(result < todayInt) answer.add(i+1);
+			 
+		 }
+		 System.out.println(answer);
+		 return answer;
+	 } //main
+	 
+	 public static int calDate(String year, String month, String day, String Type) {
+		 
+		 int yearInt = Integer.parseInt(year);
+		 int monthInt = Integer.parseInt(month);
+		 int dayInt = Integer.parseInt(day);
+		 
+		 int duration = termsMap.get(Type);
+
+		 int afterSumMonth = (monthInt + duration);
+//		 System.out.println(afterSumMonth + " / " + restSumMonth);
+		 
+		 if(afterSumMonth > 12) {
+
+			 int restSumMonth = (afterSumMonth) / 12;
+//			 System.out.println(restSumMonth);
+			 yearInt += restSumMonth;
+			 
+			 afterSumMonth = afterSumMonth - (12 * restSumMonth); // afterSumMonth 24이상일 경우도 계산
+		 }
+		 
+		 dayInt -= 1;
+		 if(dayInt == 0) {
+			 dayInt = 28;
+			 afterSumMonth -= 1;
+			 if(afterSumMonth == 0) {
+				 afterSumMonth = 12;
+				 yearInt -= 1;
+			 }
+		 }
+		 
+		 year = String.valueOf(yearInt);
+		 month = String.valueOf(afterSumMonth);
+		 if(month.length() < 2) month = "0"+month;
+		 day = String.valueOf(dayInt);
+		 if(day.length() < 2) day = "0"+day;
+		 
+//		 System.out.println(year + " / " + month + " / " + day);
+		 int result = Integer.parseInt(year + month + day);
+		 return result;
+	 }
+}


### PR DESCRIPTION
## 🔍 개요
+ #55 

## ✔️ 문제 풀이 진행 사항
+ 문제 1 백준_단지 번호 붙이기 - O
+ 문제 2 백준_공주님을 구해라! - O
+ 문제 3 백준_최단 경로 - O
+ 문제 4 프로그래머스_ 개인정보 수집기간 - O 
+ 문제 5 백준_싸이버 개강 총회 - O


## 📝 문제 풀이 전략 및 실제 풀이 방법

**단지 번호 붙이기** : 방문하지 않은 아파트 단지 한 곳에서 출발하여 BFS 탐색, 아파트가 없을 때 까지 탐색하여 탐색이 끝나게 되면 단지 갯수+1, 탐색할 때 한 단지내에 몇 개의 집이 있는지 같이 계산, BFS 탐색하면 방문처리만 해주면 되는 문제

**싸이버 개강 총회**  : 입력값들을 전부 빈칸 기준으로 먼저 쪼개줌, 이후 시간들을 : 기준으로 다시 쪼개줌 -> 22:30 이란 문자열을 쪼개서 2230으로 합친 후 int형으로 만들어 줌, 이후 채팅친 아이디들의 시간을 시작시간 종료시간과 비교해서 언제 채팅친 그룹인지 판별 -> Map 사용, 채팅 분류가 다되면 마지막엔 채팅 Id들을 담은 Set사용하여 저장된 Map 싹 훑어주고 시작, 종료시간에 채팅친 사람들 판별해줌
입력값 제한이 없는 건 EOF란 걸 써야된다던데 이거 그냥 실행시켜서는 끝나지 않아서 답 확인이 안되던데 백준에 일일이 답 제출해서 답인지 확인해야되는 건가?

**공주님을 구해라!** : 처음엔 BFS로 하면 검먹었을 때 검은 먹은 방향과 먹지 않은 방향 판단하기가 어려울 거 같아서 DFS로 풀었으나, 시간 초과가 떴다.
시간을 줄이기 위해 다시 BFS로 선회 -> 성검을 들지  않았을 때는 4방향 탐색으로 시간을 구하다가 성검을 구하는 순간 해당 위치에서 도착 지점까지의 거리를 구하고 현재까지 걸었던 거리를 더해준다 [검을 든 순간 제약 없이 움직일 수 있으니까]

**최단 경로** : 처음엔 BFS로 접근했으나 흠.. ;; , 가중치 순으로 나열하기위한 PQ와 다익스트라로 정점마다 최솟값을 비교하여 갱신시켜주는 문제, 다익스트라를 몰라서 어려웠음

**개인 정보 수집 기간** :  기본적으로 .과 공백을 기준으로 하나씩 짤라서 풂, 
첫 번째 방법은 자른 문자열을 기간만큼 더한후 20220212 | 20220314 이런 형태로 두 값을 비교해줌 -> 이거 테케 1개만 틀렸는데 뭐가 문젠지 모르겠음
두 번째 방법은 한 달은 28일 월 * 28, 일 년은 12개월 연 * 12 * 28, 로 연월을 일수로 다 풀어서 총 일수를 비교해줌 

## 🧐 참고 사항


## 📄 Reference

