### PR TITLE
김 17, 18Week

### DIFF
--- a/kdw999/17Week/PGS_호텔대실.java
+++ b/kdw999/17Week/PGS_호텔대실.java
@@ -1,0 +1,10 @@
+package Week17;
+
+public class PGS_호텔대실 {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/kdw999/17Week/PGS_호텔대실.java
+++ b/kdw999/17Week/PGS_호텔대실.java
@@ -1,10 +1,35 @@
-package Week17;
+import java.util.*;
 
-public class PGS_호텔대실 {
-
-	public static void main(String[] args) {
-		// TODO Auto-generated method stub
-
+class Solution {
+	static int maxTime = 1450;
+	static int hour = 60;
+	static int cleanTime = 10;
+	
+	public int solution(String[][] book_time) {
+        int answer = 0;
+        
+        int[] room = new int[maxTime];
+        
+        for(String[] time : book_time) {
+        	String checkIn = time[0];
+        	String checkOut = time[1];
+        	
+        	room[calTime(checkIn)] += 1;
+        	room[calTime(checkOut)+ cleanTime] += -1;
+        }
+        
+        for(int i=1; i<maxTime; i++) {
+        	room[i] += room[i-1];
+        	answer = Math.max(answer, room[i]); // 최대로 누적된 수 만큼 방이 필요
+        }
+        
+        return answer;
+    }
+	
+	public static int calTime(String time) {
+		String[] split = time.split(":"); // 입실, 퇴실 시간 쪼개기
+		String h = split[0];
+		String m = split[1];
+		return (Integer.parseInt(h) * hour) + Integer.parseInt(m);
 	}
-
 }

--- a/kdw999/17Week/백준_13458_시험감독.java
+++ b/kdw999/17Week/백준_13458_시험감독.java
@@ -1,0 +1,38 @@
+package Week17;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_13458_시험감독 {
+
+	public static void main(String[] args) throws IOException  {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int testRoom = Integer.parseInt(br.readLine());
+		int[] people = new int[testRoom];
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for(int i=0; i<people.length;i ++) {
+			people[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		st = new StringTokenizer(br.readLine());
+		
+		int mainDir = Integer.parseInt(st.nextToken());
+		int subDir = Integer.parseInt(st.nextToken());
+		
+		long minDir = testRoom;
+		
+		for(int i=0; i<people.length; i++) {
+			
+			int rest = people[i] - mainDir;
+			int needSubDir = rest / subDir;
+			if(rest%subDir > 0) needSubDir++;
+			if(needSubDir < 0 ) needSubDir = 0; 
+			
+			minDir += needSubDir;
+		}
+		
+		System.out.println(minDir);
+	}
+}

--- a/kdw999/18Week/백준_1043_거짓말.java
+++ b/kdw999/18Week/백준_1043_거짓말.java
@@ -1,0 +1,90 @@
+package Week18;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_1043_거짓말 {
+	
+	static int N, M;
+	static boolean[] man;
+	static ArrayList<Integer>[] partyGroup;
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken()); // 사람 수
+		M = Integer.parseInt(st.nextToken()); // 파티 수
+		man = new boolean[N+1]; // 진실 아는 사람인지 표시하기 위한 배열, 
+		                                  // 진실을 아는 사람과 같은 파티에 묶여서 진실을 듣게된 과장인 사람도 이후 진실로 바꿈
+		
+		st = new StringTokenizer(br.readLine()); 
+		int trueNumber = Integer.parseInt(st.nextToken()); // 진실 아는 사람 수
+
+		for(int i=0; i<trueNumber; i++) {
+			int num = Integer.parseInt(st.nextToken());
+		    man[num] = true; // 진실 아는 사람 표시
+		}
+		
+		partyGroup = new ArrayList[M];
+		for(int i=0; i<M; i++) partyGroup[i] = new ArrayList<>();
+		boolean[] partyCheck = new boolean[M]; // 과장해도 되는 파틴지 체크
+		
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine()); 
+			int partyPeople = Integer.parseInt(st.nextToken()); // 각 파티 참여자 수
+			
+			// 파티 마다 참여자 저장
+			for(int j=0; j<partyPeople; j++) {
+				partyGroup[i].add(Integer.parseInt(st.nextToken()));
+			}
+		}
+		
+		// 과장맨을 진실맨으로 바꿔주는 작업
+		for(int i=0; i<M; i++) {
+			for(int j=0; j<partyGroup[i].size(); j++) {
+				
+				int participantNum = partyGroup[i].get(j); // 각 파티마다 참여자들 번호
+				
+				boolean flag = false;
+				
+				// 각 파티에 한 명이라도 진실을 아는 자가 있다면 같은 파티에 다른 사람들도 진실맨으로 바꿔주기
+				if(man[participantNum]) {
+					for(int k=0; k<partyGroup[i].size(); k++) {
+						int num = partyGroup[i].get(k);
+						
+						// 해당 번호 참여자가 과장맨일 때만 진실맨으로
+						if(!man[num]) {
+							man[num] = true;
+							flag = true;
+						}
+					}
+					
+					// 과장맨 -> 진실맨이 됐을 때만 처음부터 다시 진실맨으로 바꿔주는 작업
+					if(flag) i=-1;
+					break;
+				}
+			}
+		}
+		
+		// 파티 참여자들의 진실맨/과장맨 변경 이후, 각 파티마다 진실/과장 파티 체크
+		for(int i=0; i<M; i++) {
+			for(int j=0; j<partyGroup[i].size(); j++) {
+				
+				int num = partyGroup[i].get(j);
+				if(man[num]) {
+					partyCheck[i] = true;
+					break;
+				}
+			}
+		}
+		
+		int result=0;
+		for(int i=0; i<M; i++) {
+			if(!partyCheck[i]) result++;
+		}
+		
+		System.out.println(result);
+	}
+	
+}

--- a/kdw999/18Week/백준_15663_N과M9.java
+++ b/kdw999/18Week/백준_15663_N과M9.java
@@ -1,0 +1,55 @@
+package Week18;
+
+import java.util.*;
+import java.io.*;
+
+public class N과M9 {
+	
+	static int[] number;
+	static int[] picks;
+	static boolean[] visit;
+	static int N,M;
+	static LinkedHashSet<String> set;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		
+		number = new int[N];
+		picks = new int[M];
+		visit = new boolean[N];
+		set = new LinkedHashSet<>();
+		
+		st = new StringTokenizer(br.readLine());
+		for(int i=0; i<N; i++) {
+			number[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		Arrays.sort(number);
+		permu(0);
+		for(String s : set) System.out.println(s);
+	}
+	public static void permu(int cnt) {
+		
+		if(cnt==M) {
+			StringBuilder sb = new StringBuilder();
+		  	for(int i=0; i<picks.length; i++) {
+		  		sb.append(picks[i]).append(" ");
+		  	}
+		  	set.add(sb.toString());
+		  	return;
+		}
+		
+		for(int i=0; i<N; i++) {
+			if(visit[i]) continue;
+			
+			visit[i]=true;
+			picks[cnt] = number[i];
+			permu(cnt+1);
+			visit[i]=false;
+		}
+	}
+}

--- a/kdw999/18Week/백준_20165_인내의도미노장인호석.java
+++ b/kdw999/18Week/백준_20165_인내의도미노장인호석.java
@@ -1,0 +1,135 @@
+package Week17;
+
+import java.util.*;
+import java.io.*;
+
+class Turn {
+	int r;
+	int c;
+	int dir;
+	
+	public Turn(int r, int c, int dir) {
+		this.r = r;
+		this.c = c;
+		this.dir = dir;
+	}
+	
+	public Turn(int r, int c) {
+		this.r = r ;
+		this.c = c;
+	}
+}
+
+public class 백준_20165_인내의도미노장인호석 {
+	
+	static int N, M, R;
+	static int[][] map;
+	static Turn[] atk, dfs;
+	static int atkPts=0;
+	static String[][] domino;
+	static boolean[][] check;
+	static int[] dr = {-1, 1, 0, 0};
+	static int[] dc = {0, 0, -1, 1};
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		R = Integer.parseInt(st.nextToken());
+
+		map = new int[N+1][M+1];
+		atk = new Turn[R];
+		dfs = new Turn[R];
+		domino = new String[N+1][M+1];
+		
+		for(int i=1; i<=N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=1; j<=M; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				domino[i][j] = "S";
+			}
+		}
+		
+		for(int i=0; i<2*R; i++) {
+			st = new StringTokenizer(br.readLine());
+			
+			// 공격
+			if(i % 2 == 0) {
+				int r = Integer.parseInt(st.nextToken());
+				int c = Integer.parseInt(st.nextToken());
+				int dir = getDir(st.nextToken());
+				atk[i/2] = new Turn(r, c, dir);
+			}
+			
+			// 수비 
+			else if(i % 2 != 0) {
+				int r = Integer.parseInt(st.nextToken());
+				int c = Integer.parseInt(st.nextToken());
+				dfs[i/2] = new Turn(r, c);
+			}
+		}
+		
+		for(int i=0; i<R; i++) {
+			
+			// 공격
+			if(domino[atk[i].r][atk[i].c].equals("S")) {
+				domino[atk[i].r][atk[i].c] = "F";
+				atkPts += atkRun(atk[i].r, atk[i].c, atk[i].dir);
+			}
+			
+			// 수비
+			domino[dfs[i].r][dfs[i].c] = "S";
+		}
+		
+		System.out.println(atkPts);
+		for(int i=1; i<=N; i++) {
+			for(int j=1; j<=M; j++) {
+				System.out.print(domino[i][j]+" ");
+			}
+			System.out.println();
+		}
+	}
+	
+	public static int atkRun(int r, int c, int dir) {
+		
+		Queue<Turn> q = new ArrayDeque<>();
+		q.add(new Turn(r, c));
+		int result = 1;
+		
+		while(!q.isEmpty()) {
+			
+			Turn t = q.poll();
+			
+			int dominoHeight = map[t.r][t.c]; // 도미노 높이
+			
+			int nr = t.r;
+			int nc = t.c;
+			
+			for(int i=1; i<dominoHeight; i++) {
+				
+				nr += dr[dir];
+				nc += dc[dir];
+				
+				// 범위
+				if(nr < 1 || nr > N || nc < 1 || nc > M) break;
+			    
+				if(domino[nr][nc].equals("F")) continue; // 쓰러진 도미노면 다음
+				domino[nr][nc] = "F";
+				result++;
+				q.add(new Turn(nr, nc));
+			}
+		}
+		
+		return result;
+	}
+	
+	public static int getDir(String str) {
+	
+		if(str.equals("E")) return 3;
+		else if(str.equals("W")) return 2;
+		else if(str.equals("S")) return 1;
+		else return 0;
+	}
+}

--- a/kdw999/18Week/백준_4803_트리.java
+++ b/kdw999/18Week/백준_4803_트리.java
@@ -1,0 +1,80 @@
+package Week18;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class 백준_4803_트리 {
+	
+	static int N, M, node, edge, tc;
+	static ArrayList<Integer>[] graph;
+	static boolean[] visited;
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		tc=0;
+		
+		while(true) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			N = Integer.parseInt(st.nextToken());
+			M = Integer.parseInt(st.nextToken());
+			
+			if(N == 0 && M == 0) break; // 마지막 입력
+			
+			visited = new boolean[N+1];
+			graph = new ArrayList[N+1];
+			
+			for(int i=1; i<=N; i++) graph[i] = new ArrayList<>();
+			for(int i=1; i<=M; i++) {
+				st = new StringTokenizer(br.readLine());
+				int x = Integer.parseInt(st.nextToken());
+				int y = Integer.parseInt(st.nextToken());
+				
+				// 양방향 그래프
+				graph[x].add(y);
+				graph[y].add(x);
+			}
+			
+			tc++;
+			int tree=0;
+			
+			for(int i=1; i<=N; i++) {
+				if(visited[i]) continue; // 방문한 노드면 다음 노드
+				
+				node=0;
+				edge=0;
+				
+				dfs(i);
+				
+				// 간선 = 정점-1;
+				// 양방향 그래프라서 간선이 2배, 간선 = (정점-1) * 2;
+				// 트리 1개 완성, 하나로 연결된 그래프가 트리인지 판단
+				if(edge == (node-1) * 2) tree++;
+			}
+			
+			sb.append("Case ").append(tc).append(": ");
+			if(tree==0) sb.append("No trees.");
+			else if(tree == 1) sb.append("There is one tree.");
+			else sb.append("A forest of ").append(tree).append(" trees.");
+			sb.append("\n");
+		}
+		
+		System.out.println(sb);
+		
+	}
+	
+	public static void dfs(int n) {
+		
+		// 배열 리스트에 저장된 간선 탐색
+		node++; // 한 정점에서 시작, 정점+1
+		edge += graph[n].size(); // 해당 정점에 연결된 간선 수 합하기
+		visited[n] = true;
+		
+		for(int n2 : graph[n]) {
+			if(visited[n2]) continue; // 방문 여부 확인
+			dfs(n2);
+		}
+	}
+}

--- a/kdw999/18Week/백준_6236_용돈관리.java
+++ b/kdw999/18Week/백준_6236_용돈관리.java
@@ -1,0 +1,50 @@
+package Week18;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_6236_용돈관리 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken()); // 요일 수
+		int M = Integer.parseInt(st.nextToken()); // 돈 꺼내는 횟수
+		
+		int[] money = new int[N];
+		
+		int left = 1; // 인출 최소 범위는 하루를 보낼 수 있는 비용 중 최대여야 하루를 보낼 수 없는 날이 없다. 
+		int right = 0; // 인출 최대 범위는 단 한 번의 인출로 모든 날을 다 보낼 수 있어야 한다.
+		
+		for(int i=0; i<N; i++) {
+			money[i] = Integer.parseInt(br.readLine());
+			left = Math.max(left, money[i]); // 인출하는 돈은 하루에 써야하는 비용들 중에서 최대 값보단 커야 모든 날 비용이 사용 가능하다.
+			right += money[i];
+		}
+		
+		int mid=0;
+		while(left <= right) { // 왼쪽 범위가 오른쪽 범위를 벗어나면 탐색 종료
+			mid = (left+right)/2; // k값을 현재 탐색하는 범위의 중간으로 잡으면서 탐색 범위를 좁혀감
+			
+			int sum=0;
+			int cnt=1;
+			
+			for(int i=0; i<N; i++) {
+			   	sum += money[i];
+			   	
+			   	if(sum > mid) { // 그 날 비용을 더해가면서 더한 비용이 현재 k보다 크게되면 돈을 새로 뽑아야 함
+			   		sum = money[i]; // 내지 못한 비용으로 시작하기 위해 초기화
+			   		cnt++; // 인출 횟수+
+			   	}
+			}
+			
+			// k 탐색 후
+			if(cnt > M) left = mid+1; // 인출 횟수가 M보다 크다면 비용이 낮아서 많이 뽑았단 소리 -> k(인출 비용)를 높이기 위해 왼쪽 범위를 이동
+			else right = mid-1; // 인출 횟수가 M보다 작다면 비용이 커서 M보다 적게 뽑았단 소리 -> 오른쪽 범위을 이동해서 mid 값 낮추기
+			                    // M과 횟수가 같아도 더 최소 비용으로 M을 만들 수 있는지 확인해줘야 함
+			                    // left <= right 까지
+		}
+		System.out.println(mid);
+	}
+}


### PR DESCRIPTION
## 🔍 개요
+ #98 

## ✔️ 문제 풀이 진행 사항
+ 백준_4803_트리 
+ 백준_1043_거짓말 
+ 백준_15663_N과M(9) 
+ 백준_6236_용돈 관리 
+ 백준_20165_인내의 도미노 장인 호석 

## 📝 문제 풀이 전략 및 실제 풀이 방법
**백준_4803_트리** : 노드와 간선의 식 -> 간선 = 정점-1을 모든 노드를 돌면서 성립하는지 체크, 성립하면 트리가 만들어짐
단 양방향이라 간선 = (노드-1) * 2 숫자가 2배가 되는 걸로 생각
dfs로 탐색하기에 연결되어 있는 그래프 단위로만 탐색함

**백준_1043_거짓말** : 모든 파티 참여자들을 확인하면서 한 파티에 진실맨이 껴있으면 해당 파티의 사람들을 모두 진실맨으로 바꿔주고, 앞선 파티에 있었던 과장맨 이었다가 진실맨이 되버린 사람들이 껴있는 파티들도 다시 확인해서 진실맨으로 바꿔주기 위해
진실맨으로 바뀐 경우 처음 부터 다시 진실맨 변경 작업 

**백준_15663_N과M(9)** : 배열 정렬, 순열, 중복 거르기

**백준_6236_용돈 관리** : 돈 증가 -> 횟수 감소, 돈 감소 -> 횟수 증가 / 중앙 범위를 옮기면서 원하는 횟수를 맞춘 상태에서 최소 금액 찾기

**백준_20165_인내의 도미노 장인 호석** : 큐에 공격 방향으로 넘어진 도미노 위치들을 저장, 반복문을 돌며 큐에 저장된 도미노 계속 꺼내면서 공격 방향으로 계속 도미노 자빠뜨리기


## 🧐 참고 사항


## 📄 Reference