### PR TITLE
김가영 19주차

### DIFF
--- a/kkayoung/19Week/BOJ_1461_도서관.java
+++ b/kkayoung/19Week/BOJ_1461_도서관.java
@@ -1,0 +1,55 @@
+// https://www.acmicpc.net/problem/1461
+import java.io.*;
+import java.util.*;
+
+public class Main {	
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+
+		// input
+		st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		List<Integer> positive = new ArrayList<>(); // 양수
+		List<Integer> negative = new ArrayList<>(); // 음수
+		st = new StringTokenizer(br.readLine());
+		for(int i=0;i<N;i++) {
+			int n = Integer.parseInt(st.nextToken());
+			if(n>0) positive.add(n);
+			else negative.add(-n);
+		}
+		
+		// 내림차순 정렬
+		Collections.sort(positive, Collections.reverseOrder());
+		Collections.sort(negative, Collections.reverseOrder());
+		
+		int p=0, n=0; // 양수 리스트 인덱스, 음수 리스트 인덱스
+		int answer = 0;
+		int psize = positive.size(); // 양수 리스트 크기
+		int nsize = negative.size(); // 음수 리스트 크기
+		while(p<psize || n<nsize) { // 원점에서 먼 곳부터 M개 지점 방문(왕복)
+			if(p<psize) {			
+				answer += positive.get(p)*2;
+				p += M;
+			}
+			if(n<nsize) {
+				answer += negative.get(n)*2;
+				n += M;
+			}
+		}
+
+		int pMax = 0;
+		int nMax = 0;
+		if(positive.size()>0) pMax = positive.get(0);
+		if(negative.size()>0) nMax = negative.get(0);
+		answer -= Math.max(pMax,nMax); // 원점에서 가장 먼 곳은 편도로 이동 (책을 모두 제자리에 놔둔 후에는 다시 0으로 돌아올 필요는 없다)
+		// output
+		bw.write(String.valueOf(answer));
+		bw.flush();
+		bw.close();
+	}
+}

--- a/kkayoung/19Week/BOJ_14716_현수막.java
+++ b/kkayoung/19Week/BOJ_14716_현수막.java
@@ -1,0 +1,67 @@
+// https://www.acmicpc.net/problem/14716
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	static int N, M;
+	static int[][] banner;
+	static int[][] dir = {{-1,0},{-1,1},{0,1},{1,1},{1,0},{1,-1},{0,-1},{-1,-1}};
+	static int TEXT = 1;
+	static int BLANK = 0;
+	static Queue<int[]> queue = new ArrayDeque<>();
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		int answer = 0;
+
+		// input
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		banner = new int[N][M];
+
+		for(int r=0;r<N;r++){
+			st = new StringTokenizer(br.readLine());
+			for(int c=0;c<M;c++){
+				banner[r][c] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		// count
+		for(int r=0;r<N;r++) {
+			for(int c=0;c<M;c++) {
+				if(banner[r][c]==BLANK) continue;
+				bfs(r, c);
+				answer++;
+			}
+		}
+		
+		// output
+		bw.write(String.valueOf(answer));
+		bw.flush();
+		bw.close();
+	}
+
+	static void bfs(int r, int c){
+		queue.offer(new int[]{r, c});
+		banner[r][c] = BLANK; // visited;
+
+		while(!queue.isEmpty()){
+			int[] now = queue.poll();
+			r = now[0];
+			c = now[1];
+
+			for(int d=0;d<8;d++){
+				int nr = r+dir[d][0];
+				int nc = c+dir[d][1];
+				if(0<=nr && nr<N && 0<=nc && nc<M && banner[nr][nc]==TEXT) {
+					queue.offer(new int[]{nr, nc});
+					banner[nr][nc] = BLANK; // visited
+				}
+			}
+		}
+	}
+}

--- a/kkayoung/19Week/BOJ_2665_미로만들기.java
+++ b/kkayoung/19Week/BOJ_2665_미로만들기.java
@@ -1,0 +1,72 @@
+// https://www.acmicpc.net/problem/2665
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	static int BLACK = 0;
+	static int WHITE = 1;
+	static class Loc{
+		int r, c, breakCnt; // row, col, 검->흰 바꾼 횟수
+		Loc(int r, int c, int breakCnt) {
+			this.r = r;
+			this.c = c;
+			this.breakCnt = breakCnt;
+		}
+	}
+	static Queue<Loc> q;
+	static int[][] dir = {{-1,0},{1,0},{0,-1},{0,1}};
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		int n = Integer.parseInt(br.readLine());
+		int[][] room = new int[n][n];
+		int[][] cnt = new int[n][n]; // (r,c)까지의 검은 방을 흰 방으로 바꾸는 최소 횟수
+		q = new ArrayDeque<>();
+
+		// input
+		for(int r=0;r<n;r++){
+			Arrays.fill(cnt[r], Integer.MAX_VALUE); // cnt 배열에는 최솟값이 저장되어야 하므로 Integer.MAX_VALUE로 초기화
+			String line = br.readLine();
+			for(int c=0;c<n;c++){
+				 room[r][c] = line.charAt(c)-'0';
+			}
+		}
+
+		q.offer(new Loc(0,0,0));
+		cnt[0][0] = 0;
+
+		while(!q.isEmpty()){
+			Loc now = q.poll();
+			int r = now.r;
+			int c = now.c;
+			int bc = now.breakCnt;
+
+			for(int d=0;d<4;d++) {
+				int nr = r+dir[d][0];
+				int nc = c+dir[d][1];
+				if(0<=nr && nr<n && 0<=nc && nc<n) {
+					if(room[nr][nc]==WHITE) { // 다음 방이 흰색
+						if(cnt[r][c]<cnt[nr][nc]) { // (r,c)에서 (nr,nc)로 갈 때 방 변경 횟수가 기존 방 변경 횟수가 더 적다면 cnt 갱신
+							cnt[nr][nc] = cnt[r][c];
+							q.offer(new Loc(nr,nc,bc));
+						}
+					} else { // black
+						if(cnt[r][c]+1<cnt[nr][nc]) { // 검은 방을 흰 방으로 바꾸고 이동했을 때 변경횟수가 기존보다 적다면
+							cnt[nr][nc] = cnt[r][c]+1; // 다음 방 변경횟수 = 현재 방 변경 횟수 + 1
+							q.offer(new Loc(nr,nc, bc+1));
+						}
+					}
+				}
+			}
+		}
+		
+		int answer = cnt[n-1][n-1];
+		// output
+		bw.write(String.valueOf(answer));
+		bw.flush();
+		bw.close();
+	}
+}

--- a/kkayoung/19Week/BOJ_3107_IPv6.java
+++ b/kkayoung/19Week/BOJ_3107_IPv6.java
@@ -1,0 +1,73 @@
+// https://www.acmicpc.net/problem/3107
+import java.io.*;
+import java.util.*;
+
+public class Main {	
+
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		// input
+		String addr = br.readLine();
+		if(addr.charAt(0)==':'&&addr.charAt(1)==':') {
+			// 주소가 ::로 시작
+			String[] tmp = addr.split("::")[1].split(":");
+			addGroup(8-tmp.length);
+			addZero(tmp);
+		}
+		else if(addr.charAt(addr.length()-1)==':'&&addr.charAt(addr.length()-2)==':') {
+			// 주소가 ::로 끝남
+			String[] tmp = addr.split("::")[0].split(":");
+			addZero(tmp);
+			sb.append(":");
+			addGroup(8-tmp.length);
+			sb.setLength(sb.length()-1); // 마지막 ':' 제거
+		}
+		else {
+			String[] tmp= addr.split("::");
+			if(tmp.length==1){
+				// 주소에 :: 가 존재하지 않음
+				addZero(tmp[0].split(":"));
+			} 
+			else {			
+				// 주소 중간에 ::가 있음
+				String[] left = tmp[0].split(":");
+				String[] right = tmp[1].split(":");
+				
+				addZero(left);
+				sb.append(":");
+				addGroup(8-(left.length+right.length));
+				addZero(right);
+			}
+			
+		}
+		
+		// output
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+	}
+
+	static void addGroup(int n) {
+		// ::로 생략한 0000: 수만큼 0000:를 추가한다
+		for(int i=0;i<n;i++){
+			sb.append("0000:");
+		}
+	}
+
+	static void addZero(String[] splitedAddr){ // 각 그룹이 4자리가 될 때까지 0 추가
+		for(int i=0;i<splitedAddr.length;i++) {
+			String hex = splitedAddr[i];
+			for(int j=0;j<4-hex.length();j++){
+				sb.append("0");
+			}
+			sb.append(hex);
+
+			if(i==splitedAddr.length-1) break;
+			sb.append(":");
+		}
+	}
+}

--- a/kkayoung/19Week/BOJ_9019_DSLR.java
+++ b/kkayoung/19Week/BOJ_9019_DSLR.java
@@ -1,0 +1,76 @@
+// https://www.acmicpc.net/problem/9019
+import java.io.*;
+import java.util.*;
+
+public class Main {	
+
+	static int from, to;
+	static Queue<Integer> q;
+	static HashMap<Integer, String> map;
+	static boolean flag;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuffer sb = new StringBuffer();
+		StringTokenizer st;
+
+		// input
+		int T = Integer.parseInt(br.readLine());
+		for(int tc=0;tc<T;tc++){
+			map = new HashMap<>();
+			st = new StringTokenizer(br.readLine());
+			from = Integer.parseInt(st.nextToken());
+			to = Integer.parseInt(st.nextToken());
+
+			sb.append(bfs()).append("\n");
+		}
+		
+		// output
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+	}
+
+	static String bfs() {
+		StringBuffer buf = new StringBuffer();
+		String res = null;
+		q = new ArrayDeque<>();
+ 		q.offer(from);
+		map.put(from, new String());
+
+		while(!q.isEmpty()){
+			int now = q.poll();
+			
+			int next = now;
+			// D
+			next = (now>=5000) ? (2*now)%10000 : 2*now;
+			res = enqueue(now, next, q, "D", buf);
+			// S
+			next = (now==0) ? 9999 : now-1;
+			if(res == null) res = enqueue(now, next, q, "S", buf);
+			// L
+			next = (now/1000)+(now%1000)*10;
+			if(res == null) res = enqueue(now, next, q, "L", buf);
+			// R
+			next = (now%10)*1000+(now/10);
+			if(res == null) res = enqueue(now, next, q, "R", buf);
+
+			if(res!=null) return res;
+		}
+		return null;
+	}
+
+	static String enqueue(int now, int next, Queue<Integer> q, String cmd, StringBuffer buf){
+		if(map.get(next) != null) return null; // next를 이미 방문함
+
+		buf.setLength(0);
+		buf.append(map.get(now)).append(cmd); // next까지 도달하는 경로를 map에 저장
+		map.put(next, buf.toString());
+		if(next == to) // next와 목표 숫자가 같다면 bfs 종료
+			return map.get(next); // 명령어 리턴
+		
+		q.offer(next);
+		return null;
+	}
+}


### PR DESCRIPTION
## 🔍 개요
+ close #112 

## ✔️ 문제 풀이 진행 사항
+ 문제 1 (김영후) 백준_9019_DSLR - 완료
+ 문제 2 (김동우) 백준_14716_현수막 - 완료
+ 문제 3 (김가영) 백준_1461_도서관 - 완료
+ 문제 4 (양윤모) 백준_3107_IPv6 - 완료
+ 문제 5 (김민) 백준_2665_미로만들기 - 완료

## 📝 문제 풀이 전략 및 실제 풀이 방법
**백준 9019 DSLR**
bfs. D, S, L, R 연산을 수행한 결과가 이전에 계산된 적이 없다면 큐에 넣어준다. 맵을 사용해서 숫자와 그 숫자를 만들기 위한 명령어를 저장했다. 만약 D, S, L, R을 수행한 결과와 타겟 숫자가 같다면 더 이상 bfs를 수행하지 않는다.

**백준 14716 현수막**
bfs. 상하좌우 대각선에 문자가 존재한다면 큐에 넣고, bfs가 종료될 때마다 answer를 1씩 증가시킨다.

**백준 1461 도서관**
원점에서 먼 곳부터 방문하면 최소 걸음으로 책을 제자리에 놔둘 수 있다.
양수, 음수를 저장할 리스트를 만들고 내림차순으로 정렬했다. 양수 리스트와 음수 리스트의 인덱스를 M씩 증가시키면서 해당 지점까지의 거리*2를 더한다. 왕복 이동이므로 2를 곱한다. 원점에서 가장 먼 거리는 편도로만 이동해야 하므로, 해당 거리를 뺀다.

**백준 3107 IPv6**
`::`이 1번 이하로 사용되기 때문에 `::`가 문자열의 처음에 나오는 경우, 가장 끝에 나오는 경우, 문자열 중간에 있는 경우, 문자열에 포함되지 않는 경우 4가지로 구분했다.  
`:`를 기준으로 나누어 그룹의 개수를 카운트하고, 그룹 수가 8개가 될 때까지 `0000:`를 추가했다.  
각 그룹을 검사하면서 문자열 길이가 4가 아니라면, 문자열 길이가 4가 될 때까지 `0`을 추가했다.  

**백준 2665 미로만들기**
bfs. r, c까지 이동하면서 방을 바꾼 횟수를 저장할 int[][] cnt를 만들었다. 다음 방 (nr,nc)에 방문한 적이 있더라도, 현재 방에서 다음 방으로 이동할 때의 방 변경 횟수가 더 적다면 nr, nc로 이동한다.


## 🧐 참고 사항

## 📄 Reference