### PR TITLE
김영후 22주차

### DIFF
--- a/hoo/22Week/Main_골드3_2638_치즈.java
+++ b/hoo/22Week/Main_골드3_2638_치즈.java
@@ -1,0 +1,91 @@
+package SSAFY.study.algo.week22;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_골드3_2638_치즈 {
+
+    static int[] dirRow = new int[] {-1, 1, 0, 0};
+    static int[] dirCol = new int[] {0, 0, -1, 1};
+    static int N, M;
+    static int[][] cheese;
+    static int melted;  // 녹은 개수 카운트, 0개가 되면 다 녹은 것
+    static int hour;    // 걸린 시간 카운트
+
+    public static void main(String[] args) throws IOException {
+        init();
+        while (melted != 0) {
+            bfs();
+            hour += 1;
+        }
+        System.out.println(hour);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        cheese = new int[N][M];
+        melted = 0;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                int info = Integer.parseInt(st.nextToken());
+                if (info == 1) melted += 1;
+                cheese[i][j] = info;
+            }
+        }
+        hour = 0;
+    }
+
+    static boolean isOuted(int row, int col) {
+        if ((0 <= row && row < N) && (0 <= col && col < M)) return false;
+
+        return true;
+    }
+
+    private static void cheeseMelt(int[][] contactInfo) {
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (contactInfo[i][j] < 2) continue;
+                cheese[i][j] = 0;
+                melted -= 1;
+            }
+        }
+    }
+
+    static void bfs() {
+        int[][] contactInfo = new int[N][M]; // "외부" 공기와 치즈가 몇 번 맞닿았는지 체크할 배열
+        boolean[][] isVisited = new boolean[N][M];
+
+        Queue<int[]> queue = new ArrayDeque<>();
+        queue.offer(new int[]{0, 0});  // 항상 시작은 맨 왼쪽 위부터
+        isVisited[0][0] = true;
+
+        while (!queue.isEmpty()) {
+            int[] nowAxis = queue.poll();
+
+            for (int d = 0; d < 4; d++) {   // 4방에 대해
+                int nextRow = nowAxis[0] + dirRow[d];
+                int nextCol = nowAxis[1] + dirCol[d];
+                if (isOuted(nextRow, nextCol)) continue;
+                // 1. 치즈에 접촉시키기
+                if (cheese[nextRow][nextCol] == 1) contactInfo[nextRow][nextCol] += 1;
+
+                // 2. 다음 외부 공기 큐에 넣기
+                if (isVisited[nextRow][nextCol] || cheese[nextRow][nextCol] != 0) continue;
+                queue.offer(new int[]{nextRow, nextCol});
+                isVisited[nextRow][nextCol] = true;
+            }
+        }
+
+        cheeseMelt(contactInfo);
+    }
+
+}

--- a/hoo/22Week/Main_골드4_1504_특정한최단경로.java
+++ b/hoo/22Week/Main_골드4_1504_특정한최단경로.java
@@ -1,0 +1,90 @@
+package SSAFY.study.algo.week22;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main_골드4_1504_특정한최단경로 {
+
+    static class Sejun implements Comparable<Sejun> {
+        int from;
+        int to;
+        int totalDist;
+
+        public Sejun(int from, int to, int totalDist) {
+            this.from = from;
+            this.to = to;
+            this.totalDist = totalDist;
+        }
+
+        @Override
+        public int compareTo(Sejun o) {
+            return this.totalDist - o.totalDist;
+        }
+    }
+
+    static int N, E;
+    static int[][] distArr;
+    static int must1, must2;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        int startToM1 = dijkstra(1, must1);
+        int startToM2 = dijkstra(1, must2);
+        int mustDist = dijkstra(must1, must2); // 반드시 지나야하는 두 점 최소 거리
+        int m1ToDestination = dijkstra(must1, N);
+        int m2ToDestination = dijkstra(must2, N);
+
+        if (startToM1 == -1 || startToM2 == -1 || mustDist == -1 || m1ToDestination == -1 || m2ToDestination == -1) System.out.println(-1);
+        else if (must1 == 1 && must2 == N) System.out.println(mustDist);
+        else System.out.println(mustDist + Math.min(startToM1 + m2ToDestination, startToM2 + m1ToDestination));
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+        distArr = new int[N+1][N+1];
+        for (int i = 0; i < E; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int dist = Integer.parseInt(st.nextToken());
+            distArr[from][to] = dist;
+            distArr[to][from] = dist;
+        }
+        st = new StringTokenizer(br.readLine());
+        must1 = Integer.parseInt(st.nextToken());
+        must2 = Integer.parseInt(st.nextToken());
+    }
+
+    static int dijkstra(int start, int end) {
+        int[] minimumDist = new int[N+1];
+        Arrays.fill(minimumDist, Integer.MAX_VALUE);
+        PriorityQueue<Sejun> pq = new PriorityQueue<>();
+        for (int i = 1; i < N+1; i++) {
+            if (distArr[start][i] == 0) continue;   // 출발점에서 이어지지 않은 곳은 패스
+            pq.offer(new Sejun(1, i, distArr[start][i]));
+            minimumDist[i] = distArr[start][i];
+        }
+
+        while (!pq.isEmpty()) {
+            Sejun now = pq.poll();
+            if (now.to == end) return now.totalDist;
+            for (int i = 1; i < N+1; i++) {
+                if (distArr[now.to][i] == 0) continue;
+                if (minimumDist[i] > minimumDist[now.to] + distArr[now.to][i]) {
+                    minimumDist[i] = minimumDist[now.to] + distArr[now.to][i];
+                    pq.offer(new Sejun(now.to, i, minimumDist[i]));
+                }
+            }
+        }
+
+        return -1;
+    }
+
+}

--- a/hoo/22Week/Main_골드5_9251_LCS.java
+++ b/hoo/22Week/Main_골드5_9251_LCS.java
@@ -1,0 +1,26 @@
+package SSAFY.study.algo.week22;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main_골드5_9251_LCS {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String input1 = br.readLine();
+        String input2 = br.readLine();
+        int[] dpArr = new int[input2.length()];
+        for (int i = 0; i < input1.length(); i++) {
+            int temp = 0;
+            for (int j = 0; j < input2.length(); j++) {
+                if (temp < dpArr[j]) temp = dpArr[j];
+                else if (String.valueOf(input1.charAt(i)).equals(String.valueOf(input2.charAt(j)))) dpArr[j] = temp + 1;
+            }
+        }
+        Arrays.sort(dpArr);
+        System.out.println(dpArr[dpArr.length-1]);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #139 

## ✔️ 문제 풀이 진행 사항
올 완


## 📝 문제 풀이 전략 및 실제 풀이 방법
+ LCS
저번에 박나린양이 출제했던 줄세우기와 같은 알고리즘의 문제였습니다. 이 문제는 제목 자체가 LCS였기에... 중략...

+ 치즈
처음에는 치즈를 기준으로 생각했습니다.  
1. 치즈를 다 돌면서 일단 두 면과 접촉하는 곳을 구한다 / 2. 그렇게 구한 곳들 중 접촉한 면이 치즈에 갇힌 공기인 곳을 찾는다...  
결국 치즈에 갇힌 공기인지 아닌지를 판단하는 것은 구역을 나누는 것이라는 생각이 들었습니다. 여기서 bfs를 사용해야겠다는 생각이 들었지만 위에서 제가 말씀드린 대로 진행 후 2번 과정에서 모두 bfs를 적용 시키기에는 조건을 따지기도, 시간도 많이 걸릴 것 같았습니다.  
그렇게 한참을 생각하다가 든 생각은 1. 치즈를 기준으로 하지 말고, 공기를 기준으로 하자 / 2. 치즈 밖의 공기는 그들끼리만 닿아있다 -> 이게 치즈를 녹이는 공기이므로 bfs를 돌며 각 공기에 대해 치즈와 닿았는지 매번 체크하자 였습니다.  
다행히 이 방법으로 풀렸는데, 다른 획기적인 방법이 있을 것 같다는 생각이 들긴 합니다.

+ 특정한 최단 경로
예전 문제 중에 이런 비슷한 문제가 있었던 것 같습니다. 아마 파티 아니면 민준이 마산 건우?였던 것으로 기억합니다.  
특정한 지점이 주어지고 그 지점을 거치는 최단 경로를 구하는 문제였습니다. 하지만 이 문제에서는 두 점이 주어졌기 때문에 그 두 점 중 무엇을 먼저 가야하는지를 판단할 수 없다고 생각해서, 처음에는 출발지 - 각 지점까지 거리 - 각 지점에서 도착점까지의 거리 를 구하고자 하지 않았습니다.  
첫 접근은 Priority queue에 들어갈 객체에 주어진 두 지점을 지나는지 판단할 boolean 배열을 넣어줬던 것입니다. 하지만 이 접근은 다익스트라가 그리디 기반의 문제풀이법임을 망각한 것이었기에 원하는 답에 접근할 수 없었습니다.(최단 거리로 이동하는 것이므로 거쳐야하는 두 점을 반드시 거칠 수는 없음, 그런 루트가 최단 경로인 경우 제외)  
그래서 어쩔 수 없이 걍 개쌩때 어거지 느낌이긴 하지만 출발지 - ( 거쳐야하는 점 1(v1), 거쳐야하는 점 2(v2) ) 거리, v1-v2 사이의 거리, (v1, v2) - 도착점 까지의 거리를 모두 구해주었습니다. 그 후 v1-v2 거리 + min(출발지-v1 + v2-도착점, 출발지-v2 + v1-도착점)으로 거리를 구해주었습니다. 하지만 문제 조건 중 v1, v2 != 1 or N 이라는 조건이 없었기에 거쳐야하는 두 점이 1, N인 경우를 고려한 조건문을 주어 그 경우는 v1-v2를 출력하게 처리했습니다.

## 🧐 참고 사항

## 📄 Reference
