### PR TITLE
김가영 23주차

### DIFF
--- a/kkayoung/23Week/BOJ_11562_백양로브레이크.java
+++ b/kkayoung/23Week/BOJ_11562_백양로브레이크.java
@@ -1,0 +1,62 @@
+// https://www.acmicpc.net/problem/11562
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int[][] dist;
+    static int INF = 50000;
+    static int n, m;
+
+	public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		    StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        dist = new int[n+1][n+1];
+        for(int i=1;i<=n;i++) Arrays.fill(dist[i], INF);
+        
+        for(int i=0;i<m;i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            dist[u][v] = 0;
+            dist[v][u] = 1;
+            if(b==1) dist[v][u] = 0;
+        }
+
+        floydWarshall();
+
+        // question
+        int k = Integer.parseInt(br.readLine());
+        for(int i=0;i<k;i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            sb.append(dist[s][e]).append("\n");
+        }
+
+		    bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+    }
+
+    static void floydWarshall() {
+        for(int i=1;i<=n;i++) {
+            for(int s=1;s<=n;s++) {
+                if(i==s) continue;
+                dist[s][s] = 0;
+                for(int d=1;d<=n;d++) {
+                    if(i==d || s==d) continue;
+                    dist[s][d] = Math.min(dist[s][d], dist[s][i] + dist[i][d]);
+                }
+            }
+        }
+    }
+}

--- a/kkayoung/23Week/BOJ_16562_친구비.java
+++ b/kkayoung/23Week/BOJ_16562_친구비.java
@@ -1,0 +1,63 @@
+// https://www.acmicpc.net/problem/16562
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static List<Integer>[] adjList;
+    static int[] A;
+    static boolean[] visited;
+    static int minimum;
+
+	public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		    StringTokenizer st;
+        int sum = 0;
+		
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        adjList = new List[N+1];
+        visited = new boolean[N+1];
+        A = new int[N+1];
+        st = new StringTokenizer(br.readLine());
+        for(int i=1;i<=N;i++) {
+            adjList[i] = new ArrayList<>();
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        // 인접 리스트 생성
+        for(int i=0;i<M;i++) {
+            st = new StringTokenizer(br.readLine());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+            adjList[v].add(w);
+            adjList[w].add(v);
+        }
+        // 친구 찾기
+        for(int i=1;i<=N;i++) {
+            if(visited[i]) continue;
+            minimum = Integer.MAX_VALUE; // 친구 무리 중 친구비 최소값
+            findFriend(i);
+            sum += minimum;
+            if(sum>k) break; // 가진 돈을 초과하면 break
+        }
+
+        String answer = (sum>k) ? "Oh no" : String.valueOf(sum);
+		    bw.write(answer);
+        bw.flush();
+        bw.close();
+    }
+
+    static void findFriend(int person) {
+        visited[person] = true; // 친구 방문 
+        minimum = Math.min(minimum, A[person]); // 친구비 최솟값을 갱신
+        for(int p:adjList[person]) { // 방문하지 않은 친구들 방문
+            if(visited[p]) continue;
+            findFriend(p);
+        }
+    }
+}

--- a/kkayoung/23Week/BOJ_22251_빌런호석.java
+++ b/kkayoung/23Week/BOJ_22251_빌런호석.java
@@ -1,0 +1,68 @@
+// https://www.acmicpc.net/problem/22251
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int[][] nums = {
+        {1, 1, 1, 1, 1, 1, 0}, // 0
+        {0, 1, 1, 0, 0, 0, 0}, // 1
+        {1, 1, 0, 1, 1, 0, 1}, // 2
+        {1, 1, 1, 1, 0, 0, 1}, // 3
+        {0, 1, 1, 0, 0, 1, 1}, // 4
+        {1, 0, 1, 1, 0, 1, 1}, // 5
+        {1, 0, 1, 1, 1, 1, 1}, // 6
+        {1, 1, 1, 0, 0, 0, 0}, // 7
+        {1, 1, 1, 1, 1, 1, 1}, // 8
+        {1, 1, 1, 1, 0, 1, 1}  // 9
+    };
+    static StringBuilder sb = new StringBuilder();
+    static int K, P;
+
+	public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		    StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+        int X = Integer.parseInt(st.nextToken());
+        
+        String x = itos(X);
+        
+        int answer = 0;
+        for(int floor=1;floor<=N;floor++) {
+            if(floor==X) continue;
+            if(cntDiff(x, itos(floor))) answer++;
+        }
+
+		bw.write(String.valueOf(answer));
+        bw.flush();
+        bw.close();
+    }
+
+    static String itos(int n) { // 정수 n을 K자리 문자열로 변형
+        sb.setLength(0);
+        for(int i=0;i<K-String.valueOf(n).length();i++) {
+            sb.append("0");
+        }
+        sb.append(n);
+        return sb.toString();
+    }
+
+    static boolean cntDiff(String a, String b) { // a에서 b로 변경 시 반전 개수가 1 이상 P이하면 true 리턴 
+
+        int result = 0;
+        for(int i=0;i<K;i++) {
+            char charA = a.charAt(i);
+            char charB = b.charAt(i);
+            if(charA==charB) continue;
+            for(int j=0;j<7;j++) {
+                if(nums[charA-'0'][j] != nums[charB-'0'][j]) result++;
+            }
+        }
+        return (0<result && result<=P);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #151  

## ✔️ 문제 풀이 진행 사항
+ 문제 1 (김동우) 백준_22251_빌런호석 - 완료
+ 문제 2 (김가영) 백준_16562_친구비 - 완료
+ 문제 3 (박나린) 백준_11562_백양로 브레이크 - 완료

## 📝 문제 풀이 전략 및 실제 풀이 방법
**백준 22251 빌런호석**
0~9는 7개의 표시등으로 표현할 수 있다. 각 숫자를 크기가 7인 배열로 저장한다.  
현재 층 X를 K자리 문자열로 변환한다. 1층부터 N층까지의 모든 층을 X에서 P개 이내의 표시등을 반전시켜서 만들 수 있는 지 확인한다.

**백준 16562 친구비**
양방향 인접 리스트를 만들고, dfs로 한 무리에 소속된 사람들을 탐색하면서 그 무리의 최소 친구비 값을 찾는다. 최소 친구비의 누적합을 출력한다. 만약 누적합이 가지고 있는 돈보다 크다면 Oh no 출력

**백준 11562 백양로 브레이크**
플로이드 워셜로 문제를 풀 때 여태껏 dist 배열을 만들고 출발지에서 도착지까의 거리를 저장했다. 그러나 이 문제는 거리가 아니라, 양방향으로 바꿔야 하는 횟수를 저장한다.   
u에서 v로 갈 수 있다면, u에서 v로 가는 경로를 양방향으로 바꿀 필요가 없으므로 0을 저장한다.  
v에서 u로 갈 수 없다면, 양방향으로 바꿔야 하므로 1을 저장한다.  
플로이드 워셜로 한 정점에서 다른 정점까지 가는데 양방향으로 바꿔야 하는 횟수의 최소값을 계산한다

## 🧐 참고 사항

## 📄 Reference
