### PR TITLE
김영후 39주차

### DIFF
--- a/hoo/39Week/Main_골드3_1005_ACMCraft.java
+++ b/hoo/39Week/Main_골드3_1005_ACMCraft.java
@@ -1,0 +1,87 @@
+package SSAFY.study.algo.week39;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_골드3_1005_ACMCraft {
+
+    static StringBuilder sb;
+
+    static class BuildingRule {
+
+        int now;
+        int next;   // 이번 건물을 지음으로써 지을 수 있는 다음 건물
+
+        public BuildingRule(int now, int next) {
+            this.now = now;
+            this.next = next;
+        }
+
+        @Override
+        public String toString() { return this.now + " " + this.next; }
+    }
+
+    static int N, K, W; // N: 건물 개수, K: 건물 규칙 개수, W: 마지막에 지어야 하는 건물
+    static int[] buildingTime;  // 각 건물을 짓는 데 필요한 시간
+    static List<List<BuildingRule>> buildingRuleList;
+    static int[] needCount; // 빌딩을 짓기 위해 전제되는 조건들 개수 저장하는 배열
+
+    public static void main(String[] args) throws IOException {
+        sb = new StringBuilder();
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        for (int t = 0; t < T; t++) {
+            init(br);
+            doACMCraft();
+        }
+        System.out.println(sb);
+    }
+
+    static void init(BufferedReader br) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        buildingTime = new int[N+1];
+        st = new StringTokenizer(br.readLine());
+        for (int n = 1; n < N+1; n++) buildingTime[n] = Integer.parseInt(st.nextToken());
+        buildingRuleList = new ArrayList<>();
+        needCount = new int[N+1];
+        for (int i = 0; i < N+1; i++) buildingRuleList.add(new ArrayList<>());
+        for (int k = 0; k < K; k++) {
+            st = new StringTokenizer(br.readLine());
+            int now = Integer.parseInt(st.nextToken());
+            int next = Integer.parseInt(st.nextToken());
+            buildingRuleList.get(now).add(new BuildingRule(now, next));    // 그 빌딩을 지은 후 다음에 지을 수 있는 빌딩 저장
+            needCount[next] += 1;   // 다음 빌딩에 필요한 전제 조건 카운트 + 1
+        }
+        W = Integer.parseInt(br.readLine());
+    }
+
+    static void doACMCraft() {
+        int[] cost = new int[N+1];
+        Queue<BuildingRule> queue = new ArrayDeque<>();
+        for (int i = 1; i < N+1; i++) {
+            if (needCount[i] == 0) {
+                cost[i] = buildingTime[i]; // 전제 조건이 필요 없는 빌딩의 비용은 그냥 자기 자신을 짓는 것으로 대체
+                List<BuildingRule> noNeedCountBuildingRuleList = buildingRuleList.get(i);
+                for (int j = 0; j < noNeedCountBuildingRuleList.size(); j++) queue.offer(noNeedCountBuildingRuleList.get(j));
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            BuildingRule nowBuilding = queue.poll();
+            int now = nowBuilding.now;
+            int next = nowBuilding.next;
+            cost[next] = Math.max(cost[now] + buildingTime[next], cost[next]);  // 다음 빌딩을 짓는 데 필요한 시간의 최댓값(전제 조건들을 모두 만족해야 하므로) 갱신
+            needCount[next] -= 1;
+            if (needCount[next] == 0) { // 다음 빌딩을 짓는 데 필요한 전제 조건들을 모두 처리했으면 다음 빌딩도 큐에 삽입
+                List<BuildingRule> noNeedBuildingRuileList = buildingRuleList.get(next);
+                for (int i = 0; i < noNeedBuildingRuileList.size(); i++) queue.offer(noNeedBuildingRuileList.get(i));
+            }
+        }
+        sb.append(cost[W]).append("\n");
+    }
+
+}

--- a/hoo/39Week/Main_골드4_1863_스카이라인쉬운거.java
+++ b/hoo/39Week/Main_골드4_1863_스카이라인쉬운거.java
@@ -1,0 +1,40 @@
+package SSAFY.study.algo.week39;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class Main_골드4_1863_스카이라인쉬운거 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int answer = 0;
+        Stack<Integer> skyLine = new Stack<>();
+        StringTokenizer st;
+        int x, y;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            x = Integer.parseInt(st.nextToken());
+            y = Integer.parseInt(st.nextToken());
+            if (skyLine.isEmpty()) {
+                if (y != 0) skyLine.push(y);
+            } else {
+                while (!skyLine.isEmpty() && skyLine.peek() > y) {
+                    skyLine.pop();
+                    answer += 1;
+                }
+                if (y != 0 && (skyLine.isEmpty() || skyLine.peek() < y)) skyLine.push(y);
+            }
+        }
+        while (!skyLine.isEmpty()) {
+            skyLine.pop();
+            answer += 1;
+        }
+        System.out.println(answer);
+    }
+
+}

--- a/hoo/39Week/Main_골드4_6987_월드컵.java
+++ b/hoo/39Week/Main_골드4_6987_월드컵.java
@@ -1,0 +1,95 @@
+package SSAFY.study.algo.week39;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main_골드4_6987_월드컵 {
+
+    static StringBuilder sb;
+    static int[] home;  // 경기를 진행하는 홈팀의 인덱스(0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4)
+    static int[] away;  // 그 상대팀의 인덱스(1, 2, 3, 4, 5, 2, 3, 4, 5, 3, 4, 5, 4, 5, 5)
+    static int[][] results;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        System.out.println(sb);
+    }
+
+    static void initMatches() {
+        home = new int[] {0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4};
+        away = new int[] {1, 2, 3, 4, 5, 2, 3, 4, 5, 3, 4, 5, 4, 5, 5};
+    }
+
+    static void init() throws IOException {
+        sb = new StringBuilder();
+        initMatches();
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int teamIndex;
+        int gameSum;    // 입력받은 게임의 개수
+        boolean initPossible;   // 입력 받은 것만으로 경기가 가능한 것이었는지 판단할 때 쓰이는 변수
+        for (int i = 0; i < 4; i++) {
+            teamIndex = 0;
+            gameSum = 0;
+            initPossible = true;
+            results = new int[6][3];
+            st = new StringTokenizer(br.readLine());
+            while (st.hasMoreTokens()) {
+                int win = Integer.parseInt(st.nextToken());
+                int draw = Integer.parseInt(st.nextToken());
+                int lose = Integer.parseInt(st.nextToken());
+                results[teamIndex][0] = win;
+                results[teamIndex][1] = draw;
+                results[teamIndex][2] = lose;
+                teamIndex++;
+                gameSum += win+draw+lose;
+                if (win+draw+lose != 5) initPossible = false;
+            }
+            if (gameSum != 30) initPossible = false;
+
+            if (initPossible) {
+                if (calcIfCan(0)) sb.append(1);
+                else sb.append(0);
+            }
+            else sb.append(0);
+            sb.append("\n");
+        }
+    }
+
+    static boolean calcIfCan(int matchNumber) {
+        if (matchNumber == 15) return true;
+
+        if (results[home[matchNumber]][0] > 0 && results[away[matchNumber]][2] > 0) {    // 홈팀의 승리인 경우
+            results[home[matchNumber]][0]--;
+            results[away[matchNumber]][2]--;
+            if (calcIfCan(matchNumber + 1)) return true;
+            results[home[matchNumber]][0]++;
+            results[away[matchNumber]][2]++;
+        }
+
+        if (results[home[matchNumber]][2] > 0 && results[away[matchNumber]][0] > 0) {    // 어웨이팀의 승리인 경우
+            results[home[matchNumber]][2]--;
+            results[away[matchNumber]][0]--;
+            if (calcIfCan(matchNumber + 1)) return true;
+            results[home[matchNumber]][2]++;
+            results[away[matchNumber]][0]++;
+        }
+
+        if (results[home[matchNumber]][1] > 0 && results[away[matchNumber]][1] > 0) {    // 무승부인 경우
+            results[home[matchNumber]][1]--;
+            results[away[matchNumber]][1]--;
+            if (calcIfCan(matchNumber + 1)) return true;
+            results[home[matchNumber]][1]++;
+            results[away[matchNumber]][1]++;
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close  #222 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ ACM Craft
  "순환하지 않는 유향 그래프(DAG, Directed Asyclic Graph)"를 탐색할 때, 각 노드를 탐색하는 데에 이전 노드의 탐색이 필요한 경우 위상 정렬이라는 알고리즘을 이용할 수 있습니다. 위상 정렬은 각 노드의 진입차수를 관리해주어야 하며, 이에 따라 진입 차수가 0인 노드와 연결된 간선들을 queue에 넣어주며 너비 우선 탐색(깊이 우선 탐색도 가능, 의미상 깊이 우선 탐색이 더 맞는 듯)을 진행해주는 방식으로 진행됩니다. 저는 이 위상 정렬을 진행하며 각 노드에서가 충족해야하는 이전 조건(이 문제에서는 해당 빌딩을 짓기 위해 이전에 지어야 하는 빌딩 건설 시간 중 최대 시간)을 배열에 저장해두고 최댓값을 갱신하는 식으로 문제를 해결했습니다.
+ 스카이라인 쉬운거
  스택을 이용했습니다. 스택이 비어있을 때와 아닐 때를 우선 나누어 주고, 비어있을 때 입력받은 건물의 높이가 0이 아니면 스택에 넣어주며 비어있지 않을 때는 입력받은 건물의 높이와 스택의 맨 위 수를 비교합니다. 맨 위 수를 비교하여 입력 받은 건물의 높이보다 높은 건물들은 pop을 진행, pop을 할 때마다 최소 건물의 수를 +1씩 해주었습니다. 입력받은 건물의 높이가 0이 아니면 ,스택이 비어 있거나 스택의 맨 위 수가 입력 받은 건물의 높이보다 낮을 때만 스택에 입력받은 건물의 높이를 넣어줍니다. 맨 마지막에는 스택에 남아있는 수를 모두 pop해주며 최소 건물의 수에 +1씩을 해주어 정답을 출력해주었습니다.
+ 월드컵
  1학기에 싸피에서 내줬던 문젠데 그때 못풀었던 문제입니다. 이번에도 못풀겠어서 다른 사람들의 풀이를 참고했습니다. 우선 경기를 치르는 팀의 인덱스를 홈, 어웨이로 나누어 저장해주고, 그 인덱스에 따라 백트래킹(재귀)을 진행했습니다. 기저 조건은 리그전의 총 경기 수인 15경기(6*5 / 2)로 잡고 그 조건을 충족하면 true를 리턴하게 해주었습니다. 15경기를 온전히 치를 수 있는 경우가 가능한 경기의 조합이며 이 조건에 다다를 때까지 입력받은 경기의 결과에서 수를 빼주며 재귀를 진행해주었습니다.

## 🧐 참고 사항

## 📄 Reference
[위상정렬(Topological Sort)을 Java로 구현해보자!!](https://codingnojam.tistory.com/66)
[백준 6987번 : 월드컵](https://maivve.tistory.com/215)