### PR TITLE
김영후 40주차

### DIFF
--- a/hoo/40Week/Main_골드3_2252_줄세우기.java
+++ b/hoo/40Week/Main_골드3_2252_줄세우기.java
@@ -1,0 +1,70 @@
+package SSAFY.study.algo.week40;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_골드3_2252_줄세우기 {
+
+    static class Edge {
+        int from;
+        int to;
+
+        public Edge(int from, int to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public String toString() { return this.from + " " + this.to; }
+    }
+
+    static int N, M;
+    static List<List<Edge>> edgeList;
+    static int[] comeIn;    // 진입 차수 저장용 배열
+
+    public static void main(String[] args) throws IOException {
+        init();
+        doLine();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        edgeList = new ArrayList<>();
+        comeIn = new int[N+1];
+        for (int i = 0; i < N+1; i++) edgeList.add(new ArrayList<>());
+        int A, B;   // A: from, B: to
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            A = Integer.parseInt(st.nextToken());
+            B = Integer.parseInt(st.nextToken());
+            edgeList.get(A).add(new Edge(A, B));
+            comeIn[B]++;    // to에 진입 차수 1 더해줌
+        }
+    }
+
+    static void doLine() {
+        StringBuilder sb = new StringBuilder();
+        Queue<Integer> queue = new ArrayDeque<>();
+        for (int i = 1; i < N+1; i++) {
+            if (comeIn[i] == 0) queue.offer(i); // 진입 차수가 0인 노드들 큐에 삽입
+        }
+
+        while (!queue.isEmpty()) {
+            int now = queue.poll();
+            sb.append(now).append(" ");
+            List<Edge> nowEdgeList = edgeList.get(now);
+            for (int i = 0; i < nowEdgeList.size(); i++) {
+                Edge nowEdge = nowEdgeList.get(i);
+                comeIn[nowEdge.to]--;
+                if (comeIn[nowEdge.to] == 0) queue.offer(nowEdge.to);
+            }
+        }
+        System.out.println(sb);
+    }
+
+}

--- a/hoo/40Week/Main_골드4_17298_오큰수.java
+++ b/hoo/40Week/Main_골드4_17298_오큰수.java
@@ -1,0 +1,55 @@
+package SSAFY.study.algo.week40;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class Main_골드4_17298_오큰수 {
+
+    static int N;
+    static int[] numbers;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        doNGE();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        numbers = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) numbers[i] = Integer.parseInt(st.nextToken());
+    }
+
+    static void doNGE() {
+        Stack<Integer> answer = new Stack<>();  // 정답 저장용 스택
+        Stack<Integer> stack = new Stack<>();   // 로직 수행용 스택
+        for (int i = N-1; i >= 0; i--) {
+            if (stack.isEmpty()) {  // 스택 비어있으면 오큰수가 없는 경우임(그 전 숫자의 오른쪽 중에서는 가장 큰 수)
+                answer.push(-1);
+                stack.push(numbers[i]);  // 자기 자신 삽입
+                continue;
+            }
+
+            if (numbers[i] < stack.peek()) {    // 스택 맨 위의 수가 지금 수보다 크면 오큰수임
+                answer.push(stack.peek());
+            }
+            else {
+                while (!stack.isEmpty() && numbers[i] >= stack.peek()) { // 스택의 가장 상위 수가 현재 숫자보다 클 때까지(오큰수가 나올 때까지) 계속 뽑음
+                    stack.pop();
+                }
+                if (stack.isEmpty()) answer.push(-1);    // 스택이 빈다면 오큰수가 없는 경우임
+                else answer.push(stack.peek());  // 스택이 안비면 오큰수 정답 스택에 저장
+            }
+            stack.push(numbers[i]);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        while (!answer.isEmpty()) sb.append(answer.pop()).append("\n");
+        System.out.println(sb);
+    }
+
+}

--- a/hoo/40Week/Main_골드5_2668_숫자고르기.java
+++ b/hoo/40Week/Main_골드5_2668_숫자고르기.java
@@ -1,0 +1,47 @@
+package SSAFY.study.algo.week40;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_골드5_2668_숫자고르기 {
+
+    static int N;
+    static HashMap<Integer, Integer> map;
+    static List<Integer> answer;
+
+    public static void main(String[] args) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        init();
+        boolean[] isChecked = new boolean[N+1];
+        for (int i = 1; i < N+1; i++) {
+            isChecked[i] = true;
+            dfs(i, isChecked, i);
+            isChecked[i] = false;
+        }
+        Collections.sort(answer);
+        sb.append(answer.size()).append("\n");
+        for (int i = 0; i < answer.size(); i++) sb.append(answer.get(i)).append("\n");
+        System.out.println(sb);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        map = new HashMap<>();
+        for (int i = 1; i < N+1; i++) map.put(i, Integer.parseInt(br.readLine()));
+        answer = new ArrayList<>();
+    }
+
+    static void dfs(int n, boolean[] isChecked, int target) {
+        if (!isChecked[map.get(n)]) {
+            isChecked[map.get(n)] = true;
+            dfs(map.get(n), isChecked, target);
+            isChecked[map.get(n)] = false;  // 자바에서 배열은 참조타입이므로 파라미터로 변수를 전달한 경우에도 모든 경로 탐색을 위해서는 꼭 방문 체크 해제를 처리해주어야 함.
+        }
+
+        if (map.get(n) == target) answer.add(target);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #226 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 줄 세우기
  이게 의도한 건 아니었는데 지난 주 가영님이 냈던 ACM크래프트와 같은 유형이었습니다. ACM크래프트를 풀고 난 후에 " 노드 간의 순서가 정해져 있다 -> 위상 정렬이 아닐까? " 라는 생각이 자리잡게 되었고, 이 문제가 그런 문제였기 때문에 그렇게 풀었습니다.  
  위상정렬의 개념인 진입 차수가 0인 노드들을 큐에 삽입, 그들이 향하는 노드들의 진입 차수를 차감하며 계속 큐에 삽입해준다를 수행해줍니다. 그와 동시에 큐에서 poll을 수행했을 때 나오는 노드는 자기 차례가 된(?) 노드이므로, 그 전 순서 노드들은 모두 처리가 됐다고 판단하여 바로 StringBuildef에 append 해주어 출력하였습니다.
+ 숫자 고르기
  이 문제는 혼자 힘으로 해결못했습니다. 처음 시도한 방법은 map에 각 숫자에 매핑되는 아랫 수들을 저장, 윗수와 아랫수에 해당하는 set에 저장해가며 깊이 우선 탐색을 수행하고 그들이 같은지 비교하는 방식으로 시도했습니다. 이 방식은 메모리 초과를 당했구요, 떠오르는 방법이 없어 다른 분들의 풀이를 참고했습니다. 
  그랬더니 싸이클 이런 소리를 하고 있길래 뭔 소린가 했더니 문제의 조건을 충족하려면 A->B, B->A 혹은 A->A인 구조인 숫자들, 즉 깊이 우선 탐색의 마지막에 자기 자신으로 돌아오는 구조여야 한다는 것이었습니다. 그래서 그냥 그렇게 했습니다... 이 문제를 풀다가 얻은 건, 배열은 자바에서 call by reference로 동작하기 때문에 각기의 함수 내에서 값을 변경하더라도 전체에 영향을 미친다는 것이었습니다. 이게 자주 사용하지 않는다면 까먹기 딱 쉬운 내용이어서 저도 까먹고 있었고 이번 기회에 다시 상기할 수 있었습니다.
+ 오큰수
  가장 마지막에 들어간 숫자가 가장 처음 나온다(LIFO) 의 개념을 이용했습니다. 문제를 풀기 위해서는 현재 수의 오른쪽에서 현재 수보다 큰 숫자 중 가장 왼쪽에 있는 수가 필요합니다. 오른쪽부터 삽입을 시작한 스택에 대해서 현재 수보다 큰 수가 나올 때까지 pop을 해주면, 현재 수보다 큰 수가 나왔을 때 현재 수의 오른쪽 숫자 중 왼쪽에 있는 수가 나올 것입니다. 문제 풀이의 진행을 오른쪽에서 왼쪽으로 진행하면 모든 수에 대해서 이런 매커니즘이 적용됩니다. 이런 식의 비교 후 매번 스택에 현재 수도 삽입을 해주어야 주어진 배열에 대해 계속적인 진행이 가능합니다.

## 🧐 참고 사항

## 📄 Reference
