### PR TITLE
김영후 41주차

### DIFF
--- a/hoo/41Week/Main_골드3_20303_할로윈의양아치.java
+++ b/hoo/41Week/Main_골드3_20303_할로윈의양아치.java
@@ -1,0 +1,79 @@
+package SSAFY.study.algo.week41;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_골드3_20303_할로윈의양아치 {
+
+    static int N, M, K; // N: 거리의 아이들 수, M: 주어지는 친구 관계 수, K: 어른들한테 들키는 임계값
+    static int[] initCandies;   // 최초 입력 받은 각 어린이 별 사탕 개수
+    static int[] captains;   // 각 어린이들의 대장 친구(union의 부모 값)를 저장
+
+    public static void main(String[] args) throws IOException {
+        init();
+        halloween();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        initCandies = new int[N+1];
+        for (int i = 1; i < N+1; i++) initCandies[i] = Integer.parseInt(st.nextToken());
+
+        captains = new int[N+1];
+        for (int i = 1; i < N+1; i++) captains[i] = i; // 초기 대장 친구는 자기 자신, 친구 수는 자기 자신만 있으므로 1
+        int from, to;
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            from = Integer.parseInt(st.nextToken());
+            to = Integer.parseInt(st.nextToken());
+            union(from, to);    // 입력받으며 각 친구들의 대장 친구를 저장해줌
+        }
+    }
+
+    static int find(int a) {
+        if (captains[a] == a) return a;
+        return captains[a] = find(captains[a]);
+    }
+
+    static void union(int a, int b) {
+        int captainA = find(a);
+        int captainB = find(b);
+        if (captainA != captainB) {
+            captains[captainB] = captainA;
+        }
+    }
+
+    static void halloween() {
+        List<Integer> captainList = new ArrayList<>();  // 우선 대장들을 저장
+        captainList.add(0); // 인덱스 맞추기 위해서 숫자 하나 미리 넣어줌
+        int[] candies = new int[N + 1];
+        int[] friendCounts = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            int captain = find(i);
+            if (i == captain) captainList.add(i);
+            candies[captain] += initCandies[i]; // 각 아이들의 대장 어린이에게 사탕 수 카운트해줌
+            friendCounts[captain]++;
+        }
+
+        int[][] dpArr = new int[captainList.size()][K]; // 여기서부터 Knapsack 알고리즘
+        int captainChild, friendCount, candy;
+        for (int i = 1; i < captainList.size(); i++) {
+            captainChild = captainList.get(i);
+            friendCount = friendCounts[captainChild];
+            candy = candies[captainChild];
+            for (int j = 0; j < K; j++) {
+                if (j < friendCount) dpArr[i][j] = dpArr[i-1][j];
+                else dpArr[i][j] = Math.max(dpArr[i-1][j], dpArr[i-1][j-friendCount] + candy);
+            }
+        }
+        System.out.println(dpArr[captainList.size() - 1][K - 1]);
+    }
+}

--- a/hoo/41Week/Main_골드3_2143_두배열의합.java
+++ b/hoo/41Week/Main_골드3_2143_두배열의합.java
@@ -1,0 +1,68 @@
+package SSAFY.study.algo.week41;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class Main_골드3_2143_두배열의합 {
+
+    static int T, n, m;
+    static int[] A, B;
+    static int[] sumA, sumB;    // 부 배열은 배열 내의 연속 적인 숫자들이니, 합을 미리 구해두는 용도로 쓸 배열(최대값 1,000 * 1,000,000 이므로 int 가능)
+
+    public static void main(String[] args) throws IOException {
+        init();
+        doArraySum();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        T = Integer.parseInt(br.readLine());
+        n = Integer.parseInt(br.readLine());
+        A = new int[n];
+        sumA = new int[n+1];    // 초기화와 구간 합 구하기 위해 사이즈보다 +1 해줘서 0번 인덱스에는 0을 저장
+        initArrays(br, n, A, sumA); // 자바에서 배열은 call by reference라서 파라미터로 넘겨주면 함수를 통한 값 초기화 가능
+        m = Integer.parseInt(br.readLine());
+        B = new int[m];
+        sumB = new int[m+1];
+        initArrays(br, m, B, sumB);
+    }
+
+    static void initArrays(BufferedReader br, int num, int[] arr, int[] sumArr) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < num; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+            sumArr[i+1] += (sumArr[i] + arr[i]);
+        }
+    }
+
+    static void doArraySum() {
+        // 부분 배열 합의 빈도수를 저장할 맵
+        Map<Integer, Integer> subSumMapA = new HashMap<>();
+
+        // A 배열의 부분 배열 합을 구하여 맵에 저장
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j <= n; j++) {
+                int subSum = sumA[j] - sumA[i];
+                subSumMapA.put(subSum, subSumMapA.getOrDefault(subSum, 0) + 1);
+            }
+        }
+
+        long cnt = 0;
+        // B 배열의 부분 배열 합을 구하여 A 배열의 부분 배열 합과 비교
+        for (int i = 0; i < m; i++) {
+            for (int j = i + 1; j <= m; j++) {
+                int subSum = sumB[j] - sumB[i];
+                if (subSumMapA.containsKey(T - subSum)) {
+                    cnt += subSumMapA.get(T - subSum);
+                }
+            }
+        }
+        System.out.println(cnt);
+    }
+
+}

--- a/hoo/41Week/Main_골드5_12919_A와B2.java
+++ b/hoo/41Week/Main_골드5_12919_A와B2.java
@@ -1,0 +1,44 @@
+package SSAFY.study.algo.week41;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main_골드5_12919_A와B2 {
+
+    static String S, T;
+    static boolean isPossible;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        S = br.readLine();
+        T = br.readLine();
+        isPossible = false;
+        aAndB(T);
+        if (isPossible) System.out.println(1);
+        else System.out.println(0);
+    }
+
+    static void aAndB(String input) {
+        if (isPossible) return; // 이미 가능하다고 판단됐으면 수행하지 않음
+        if (input.length() == S.length()) { // 기저, 원래 문자열의 길이에 도달했을 때
+            if (input.equals(S)) isPossible = true;
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (String.valueOf(input.charAt(input.length()-1)).equals("A")) {   // A를 추가했던 경우라면
+            sb.append(input);
+            sb.deleteCharAt(input.length()-1);
+            aAndB(sb.toString());
+        }
+        if (String.valueOf(input.charAt(0)).equals("B")) {  // A를 추가한 게 아니라 B를 추가하고 뒤집은 경우였을 수도 있으므로
+            sb = new StringBuilder();
+            sb.append(input);
+            sb.reverse();
+            sb.deleteCharAt(input.length()-1);
+            aAndB(sb.toString());
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #230 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 할로윈의 양아치
  접근법으로 처음 떠올랐던 건 유니온 파인드를 통해 대장 친구를 정해주고 각 친구들 별 친구 수를 저장해준 후, 1차원 배열을 이용해서 각 친구 네트워크에 속한 어린이들의 사탕 수의 합을 저장해주고 그를 이용하려고 했습니다. 하지만 최종 어린이 수의 제한, 각 친구 네트워크가  소유한 사탕의 수를 고려해야했으므로 1차원으로는 충분하지 않고, 2차원 배열을 이용한 dp를 해주어야 했습니다. 이는 문제 유형의 배낭 문제(Knapsack)을 보고 알게 되었습니다.  
  그렇게 친구 수의 최종 제한만큼의 길이를 내부 배열의 길이로 가지고, 총 대장 친구의 길이 만큼을 길이로 하는 2차원 배열을 이용하게 되었습니다. 각 대장 친구 별로 네트워크에 속한 친구 수, 그들이 가진 사탕의 총합을 이용하여 본인의 네트워크가 가진 친구 수를 초과하는 인덱스에 최대값을 갱신해주는 식으로 진행하였습니다. 최종 점화식은 j >= friendCount에 대해 dpArr[i][j] = Math.max(dpArr[i-1][j], dpArr[i-1][j-friendCount] + candy) 와 같습니다. j < friendCount일 경우에는 dpArr[i][j] = dpArr[i-1][j]와 같습니다.  

+ 두 배열의 합
  배열 내의 값들로 어떤 기준을 충족해야 한다 -> 대부분 투 포인터 느낌으로 생각하고 문제에 접근하고 있습니다. 그 전에 이 문제는 배열 내에서 연속하는 값들을 '부 배열' 이라는 이름으로 칭하고 이들의 합을 이용한 풀이를 요구하고 있었습니다. 배열 내 연속되는 값들의 합이 요구되는 것 같아 누적합을 우선 저장해두었고, 부 배열이 어느 인덱스에서 시작하든 누적 합을 이용해 구간 합을 구하면 됐으므로 우선적으로 구하게 되었습니다. 
  이후의 접근에 대해서는 투 포인터를 이용해보려 했으나 어떻게 적용을 해야할 지 감이 오지 않았고, 문제에서 요구한 A 배열과 B 배열의 부 배열들의 합에 대한 풀이를 위해서는 A의 구간 합을 이용할 수 있을 것 같았습니다. 그리하여 A 배열의 모든 구간 합을 N^2의 시간 복잡도로 구해 Map에 (구간 합의 값, 그 값을 가지는 구간 합의 개수) 형태로 저장했습니다. 이후 B에 대해서 2중 for문을 돌며 구간 합을 구해주며 충족해야 하는 값인 T-B의 구간합이 저장해둔 A의 map에 저장돼 있는 지 판단, 저장돼있다면 그 key의 value만큼을 출력해줄 정답에 더해주는 방식으로 문제를 해결했습니다.
  투 포인터를 이용하고자 한다면 누적합을 제가 했던 방식 처럼 맨앞에서 부터 i번 인덱스까지의 합으로 저장해주는 것이 아니라, i번째 부터 시작해서 마지막 인덱스까지의 누적 합을 구해주어 정렬 후 left pointer는 A 배열의 누적 합에 대해, right pointer는 B 배열의 누적 합에 대해 적용해주는 방식으로 진행되는 것 같습니다.  

+ A와 B 2
  재귀를 이용하면 되겠다고 생각했고, 그렇게 했습니다. 처음에는 S를 변경해가며 T에 맞추었을 때 중단을 하고자 했고, 시간 초과가 발생했습니다. 이는 재귀 함수의 input에 대해 무조건 적으로 1. A를 추가한다, 2. B를 추가하고 뒤집는다를 수행해나가기 때문에 2^(T의 길이-S의 길이) 만큼의 시간 복잡도를 요구하는 풀이였기 때문입니다.
  그리하여 T의 변화를 되돌려가는 식으로 S에 맞는지 확인하는 방식으로 수정, 불필요한 탐색을 줄여 시간초과를 면할 수 있었습니다. 

## 🧐 참고 사항


## 📄 Reference
