### PR TITLE
김영후 49주차

### DIFF
--- a/hoo/49Week/Main_2529_부등호.java
+++ b/hoo/49Week/Main_2529_부등호.java
@@ -1,0 +1,69 @@
+package SSAFY.study.algo.week49;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main_2529_부등호 {
+
+    static int k;
+    static String[] inequalitySigns;
+    static long minNumber, maxNumber;
+    static String minNumberString, maxNumberString;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        boolean[] isUsed;
+        for (int i = 0; i <= 9; i++) {  // 0 ~ 9 사용해서 숫자 만들기
+            isUsed = new boolean[10];
+            isUsed[i] = true;
+            calcCase(String.valueOf(i), isUsed, 1);
+        }
+        System.out.println(maxNumberString);
+        System.out.println(minNumberString);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        k = Integer.parseInt(br.readLine());
+        inequalitySigns = br.readLine().split(" ");
+        minNumber = 9_876_543_211L; // 가능한 최대 수 9_876_543_210
+        maxNumber = 0;  // 가능한 최소 수 012
+        minNumberString = "";
+        maxNumberString = "";
+    }
+
+    static void calcCase(String made, boolean[] isUsed, int count) {    // count: 골라진 숫자의 개수
+        if (count == k + 1) {   // 기저, 숫자가 만들어졌으면 최대와 최솟값 갱신
+            Long madeNumber = Long.valueOf(made);
+            if (madeNumber < minNumber) {   // 최솟값 갱신한 경우
+                minNumber = madeNumber;
+                minNumberString = made;
+            } else if (madeNumber > maxNumber) {
+                maxNumber = madeNumber;
+                maxNumberString = made;
+            }
+            return;
+        }
+
+        String inequalitySign = inequalitySigns[count-1];
+        int beforeNumber = Integer.parseInt(String.valueOf(made.charAt(count-1)));
+        for (int i = 0; i <= 9; i++) {
+            if (isUsed[i]) continue;
+
+            switch (inequalitySign) {   // 조건에 안맞는 경우들은 건너 뜀
+                case ">":
+                    if (beforeNumber <= i) continue;
+                    break;
+                case "<":
+                    if (beforeNumber >= i) continue;
+                    break;
+            }
+            isUsed[i] = true;
+            calcCase(made + String.valueOf(i), isUsed, count+1);
+            isUsed[i] = false;
+        }
+    }
+
+}

--- a/hoo/49Week/Main_6198_옥상정원꾸미기.java
+++ b/hoo/49Week/Main_6198_옥상정원꾸미기.java
@@ -1,0 +1,42 @@
+package SSAFY.study.algo.week49;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class Main_6198_옥상정원꾸미기 {
+
+    static int N;
+    static int[] heights;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        countCanSee();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        heights = new int[N];
+        for (int i = 0; i < N; i++) {
+            heights[i] = Integer.parseInt(br.readLine());
+        }
+    }
+
+    static void countCanSee() {
+        long answer = 0;    // 접근 방식: "현재 빌딩을 볼 수 있는" 빌딩을 카운트 하기
+        Stack<Integer> stack = new Stack<>();
+        for (int i = 0; i < N; i++) {   // 모든 건물에 대해 수행
+            while (!stack.isEmpty()) {  // 스택이 비거나
+                if (heights[i] < stack.peek()) break;   // 지금 빌딩보다 높은 빌딩이 나올때까지
+                stack.pop();    // 스택에 있는 빌딩들 모두 제거
+            }
+            answer += stack.size(); // 그 후 스택에 남아있는 빌딩이 현재 빌딩을 볼 수 있는 빌딩들임
+            stack.push(heights[i]); // 그 후 해당 건물 스택에 넣어줌
+        }
+
+        System.out.println(answer);
+    }
+
+}

--- a/hoo/49Week/PGMS_도넛과막대그래프.java
+++ b/hoo/49Week/PGMS_도넛과막대그래프.java
@@ -1,0 +1,113 @@
+package programmers.lv2;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+
+public class PGMS_도넛과막대그래프 {
+
+    int NODE_LIMIT = 1_000_000;
+
+    class Edge {
+        int from;
+        int to;
+
+        public Edge(int from, int to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public String toString() { return this.from + " " + this.to; }
+    }
+
+    List<List<Edge>> edgeList;
+    int[] incomes;  // 노드 별 진입차수 저장
+    int[] answer;
+    int highestNode;
+
+    public int[] solution(int[][] edges) {
+        answer = new int[4];
+        initEdgeList(edges);
+        findNewNode();
+        countGraphs();
+
+        return answer;
+    }
+
+    void initEdgeList(int[][] edges) {  // O(N)
+        edgeList = new ArrayList<>();
+        for (int i = 0; i <= NODE_LIMIT; i++) edgeList.add(new ArrayList<>());
+        incomes = new int[NODE_LIMIT+1];
+        highestNode = 0;
+        int from, to;
+        for (int i = 0; i < edges.length; i++) {
+            from = edges[i][0];
+            to = edges[i][1];
+            edgeList.get(from).add(new Edge(from, to));
+            incomes[to]++;
+
+            highestNode = Math.max(Math.max(from, to), highestNode);
+        }
+    }
+
+    void findNewNode() {    // O(N)
+        for (int i = 1; i < incomes.length; i++) {
+            if (incomes[i] == 0 && edgeList.get(i).size() > 1) {
+                answer[0] = i;
+                break;
+            }
+        }
+    }
+
+    void countGraphs() {
+        List<Edge> newNodeEdgeList = edgeList.get(answer[0]);
+        for (int i = 0; i < newNodeEdgeList.size(); i++) incomes[newNodeEdgeList.get(i).to] -= 1;   // 새로 추가한 노드에서 진입차수가 추가되는 노드들에 대해 이 노드와 연결 해제 처리
+
+        for (int i = 0; i < newNodeEdgeList.size(); i++) {
+            bfs(newNodeEdgeList.get(i).to);  // 새로 추가한 노드가 향하는 노드를 출발점으로 그래프 탐색 수행
+        }
+    }
+
+    void bfs(int start) {
+        List<Edge> initEdgeList = edgeList.get(start);
+        if (incomes[start] == 0 || initEdgeList.size() == 0) {  // 막대 그래프의 양 끝 노드인 경우이므로 카운트 +1하고 종료
+            answer[2] += 1;
+            return;
+        }   // 이 경우 안따져주니 테스트 9번에서 시간초과 발생함
+
+        // 막대 그래프는 노드 개수 = 간선 개수 + 1 / 도넛은 모든 노드에서 차수가 1, 1 / 8자는 한 노드에서 차수가 2, 2인 곳이 있음
+        boolean[] isChecked = new boolean[NODE_LIMIT+1];
+        isChecked[start] = true;
+        int nodeCount = 1;
+        int edgeCount = 0;
+        Queue<Edge> q = new ArrayDeque<>();
+        for (int i = 0; i < initEdgeList.size(); i++) {
+            isChecked[initEdgeList.get(i).to] = true;
+            q.offer(initEdgeList.get(i));
+        }
+
+        Edge now;
+        List<Edge> nextEdgeList;
+        while (!q.isEmpty()) {
+            now = q.poll();
+            nextEdgeList = edgeList.get(now.to);
+
+            Edge next;
+            for (int i = 0; i < nextEdgeList.size(); i++) {
+                edgeCount += 1; // 방문했던 노드라도 간선은 카운트 해줘야 함
+                next = nextEdgeList.get(i);
+                if (isChecked[next.to]) continue;
+                isChecked[next.to] = true;
+                q.offer(next);
+                nodeCount += 1;
+            }
+        }
+
+        if (nodeCount == edgeCount + 1) answer[2] += 1;
+        else if (nodeCount == edgeCount - 1) answer[3] += 1;
+        else if (nodeCount == edgeCount) answer[1] += 1;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #264 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 부등호
주어지는 k의 개수가 최대 9개이므로 dfs로 문제를 해결했습니다. 부등호 조건을 만족하지 않는 숫자를 탐색할 경우는 건너뛰는 방식으로 구현했으며, 이 부분에서 백트래킹 적인 요소가 있다고 볼 수 있을 것 같습니다. 만들어진 수의 상태는 '01234..'와 같은 경우도 존재하므로 String으로 관리했습니다.
 
+ 도넛과 막대 그래프
 제일 먼저 새로운 노드 하나를 추가하기 전 그래프들은 연결지점 없이 각자 존재했을 거라는 생각으로 접근했습니다. 이런 시각으로 봤을 때 새로운 노드는 진입차수가 0입니다. 또한 문제 조건에서 도넛, 막대, 8자 모양 그래프 개수의 합은 2 이상임을 명시했으므로 이 두 조건을 이용해 '진입차수가 0이며 해당 노드에서 나가는 간선의 개수가 2이상인' 노드를 찾으면 새로 추가한 노드를 찾을 수 있습니다.  
이후에는 연결된 그래프에서 새로운 노드를 제거했다고 생각하고 문제를 풀이하였습니다. 우선 새로 추가한 노드와 연결된 노드의 진입 차수를 -1씩 해주어 연결이 끊어진 형태를 표현해주었습니다. 각 그래프들에 대한 모양 판별은 새로 추가한 노드와 연결된 노드로부터 시작, bfs를 이용하여 그래프를 탐색하며 노드와 간선 개수의 관계를 이용해 파악하였습니다. 도넛 그래프는 노드와 간선의 개수가 같고 막대 그래프는 노드가 간선보다 한 개 많으며, 8자 그래프는 노드 개수가 간선 개수보다 한 개 작음을 이용합니다. 
이때 막대 그래프의 경우 탐색 전 파악이 가능합니다. 탐색을 시작한 노드의 진입차수가 0이거나 진출 간선이 0개이면 막대 그래프의 양 끝 노드이므로, 탐색 전 막대 그래프임을 표시해줄 수 있습니다.  
각 모양 그래프 개수의 합과 각 그래프 별 노드와 간선의 관계 같은 **문제에서 주어진 조건을 이용**하고, 주어진 그래프를 머릿속으로 그려보며 추가된 노드를 끊는 것과 같은 **문제 해결에서의 우선순위를 파악**하면 해결할 수 있는 문제였습니다.

+ 옥상 정원 꾸미기
 N이 8만이라 가장 직관적인 N^2의 순회로는 해결할 수 없는 문제임을 파악했습니다. 그럼 반복문 한 번만에 해결이 가능해야 한다는 뜻이므로 그 안에서 해결법을 생각해보았으나, 떠오르지 않아 문제 분류를 참고했습니다.(참고로 저는 토탐정이라는 크롬 익스텐션을 사용하고 있어서 10분이 지나야 문제 분류를 볼 수 있습니다. 이거 좋아요 써보시길.)
 하지만 분류를 보고도 어지럽더라고요. 직관적인 해결법이 현재 빌딩을 기준으로 현재 빌딩을 볼 수 있는 빌딩의 개수를 카운트 하는 것이었고, 그를 위해서는 스택에서 현재 빌딩보다 높은 건물이 맨 위에 위치할 때까지 pop을 하고 그때의 스택 사이즈를 카운트하는 것이었기 때문입니다. 이 과정에서 반복문 내에서 반복문이 꽤나 돌 거라고 생각했기 때문입니다. 하지만 그렇게 문제를 풀이 후 우선 제출을 해봤는데, 통과가 되어서 시간 복잡도를 다시 한 번 돌이켜보게 되었습니다.
 그 결과 제가 잘못 생각하고 있었다는 사실을 알 수 있었습니다. for문 안에서 while문이 돈다고 해서 N^2에 가까운 시간복잡도라고 생각했는데, 어차피 stack에 들어가는 빌딩들은 각각 한 번만 push되고 pop되므로 최종 시간 복잡도는 N이었습니다. 이렇게 하며 대충적인 틀 보다는 코드 동작 자체에 대한 이해를 바탕으로 시간 복잡도를 생각해보는 것의 중요성을 알 수 있었습니다.

## 🧐 참고 사항


## 📄 Reference
