### PR TITLE
김동우 52주차

### DIFF
--- a/kdw999/52Week/Softeer_동계테스트시점예측.java
+++ b/kdw999/52Week/Softeer_동계테스트시점예측.java
@@ -1,0 +1,110 @@
+package Week52;
+
+import java.io.*;
+import java.util.*;
+
+public class Softeer_동계테스트시점예측 {
+
+	static int N, M;
+	static int[][] map;
+	static int[] dr = {1, -1, 0, 0};
+	static int[] dc = {0, 0, 1, -1};
+	static boolean[][] isVisited;
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		
+		map = new int[N][M];
+		
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<M; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		int result = 0;
+		
+		while(true) {
+            isVisited = new boolean[N][M];
+			airCheck(); 
+		
+		List<int[]> list = new ArrayList<>(); // 녹는 위치 저장
+
+		for(int i=1; i<N-1; i++) {
+			for(int j=1; j<M-1; j++) {
+				if(map[i][j] == 1) {
+					
+					boolean canMelting =  meltSnow(i, j);
+					if(canMelting) list.add(new int[] {i, j});
+				}
+			}
+		}
+		if(list.size() == 0) break;
+		result++;
+		
+		// 삭제될 눈 -1(외부공기)처리
+		for(int i=0; i<list.size(); i++) {
+			int[] idx = list.get(i);
+			map[idx[0]][idx[1]] = -1;
+		}
+		
+	  }
+		System.out.println(result);
+	}
+	
+	static void airCheck(){
+		
+		Queue<int[]> q = new ArrayDeque<>();
+		
+		q.offer(new int[] {0, 0});
+		
+		map[0][0] = -1;
+		isVisited[0][0] = true;
+		
+		while(!q.isEmpty()) {
+
+			int[] qp = q.poll();
+			
+			for(int i=0; i<4; i++) {
+				
+				int nr = qp[0] + dr[i];
+				int nc = qp[1] + dc[i];
+			
+				if(nr < 0 || nr >= N ||  nc < 0 || nc >= M) continue;
+				if(map[nr][nc] == 1 || isVisited[nr][nc]) continue;
+
+					map[nr][nc] = -1;
+
+				
+				q.offer(new int[] {nr, nc});
+				isVisited[nr][nc] = true;
+			}
+
+		}
+	}
+	
+    static boolean meltSnow(int r, int c){
+			
+			int outdoorAir = 0;
+			
+			for(int i=0; i<4; i++) {
+				
+				int nr = r + dr[i];
+				int nc = c + dc[i];
+			
+				// 외부 공기 닿은 횟수 체크
+				if(map[nr][nc] == -1) {
+					outdoorAir += 1;
+				}
+			}
+			if(outdoorAir >= 2) return true;
+			return false;
+		}
+	
+}

--- a/kdw999/52Week/백준_1577_도로의갯수.java
+++ b/kdw999/52Week/백준_1577_도로의갯수.java
@@ -1,0 +1,61 @@
+package Week52;
+
+import java.util.*;
+import java.io.*;
+
+
+public class 백준_1577_도로의갯수 {
+
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		long[][] dp = new long[N+1][M+1];
+		
+		int[][] horizontal = new int[N+1][M+1];
+		int[][] vertical = new int[N+1][M+1];
+		
+		int K = Integer.parseInt(br.readLine());
+		
+		for(int i=0; i<K; i++) {
+			
+			st = new StringTokenizer(br.readLine());
+			
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			int d = Integer.parseInt(st.nextToken());
+			
+			if(b == d) horizontal[Math.min(a, c)][b] = 1;
+			else vertical[a][Math.min(b, d)] = 1;
+			
+		}
+		
+		for(int i=1; i<N+1; i++) {
+			if(horizontal[i-1][0] == 1) break;
+			dp[i][0] = 1L;
+		}
+		
+		for(int i=1; i<M+1; i++) {
+			if(vertical[0][i-1] == 1) break;
+			dp[0][i] = 1L;
+		}
+		
+		for(int i=1; i<dp.length; i++) {
+			for(int j=1; j<dp[0].length; j++) {
+				
+				dp[i][j] = dp[i][j-1] + dp[i-1][j];
+				
+				// 공사중이면 가짓수 빼기
+				if(horizontal[i-1][j] == 1) dp[i][j] -= dp[i-1][j];
+				if(vertical[i][j-1] == 1) dp[i][j] -= dp[i][j-1];
+			}
+		}
+		
+		System.out.println(dp[N][M]);
+	}
+}

--- a/kdw999/52Week/백준_1956_운동.java
+++ b/kdw999/52Week/백준_1956_운동.java
@@ -1,0 +1,63 @@
+package Week52;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_1956_운동 {
+ 
+	final static int MAXVAL = 987654321;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int V = Integer.parseInt(st.nextToken());
+		int E = Integer.parseInt(st.nextToken());
+		
+		int result = MAXVAL;
+		
+		int[][] dist = new int[V+1][V+1];
+		
+		for(int i=1; i<=V; i++) {
+			for(int j=1; j<=V; j++) {
+				
+				if(i==j) dist[i][j] =0; 
+				else dist[i][j] = MAXVAL;
+			}
+		}
+		
+		for(int i=0; i<E; i++) {
+			
+			st = new StringTokenizer(br.readLine());
+			
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			int distance = Integer.parseInt(st.nextToken());
+			
+			dist[from][to] = distance;
+		}
+
+		for(int i=1; i<=V; i++) {
+			for(int j=1; j<=V; j++) {
+				if(i==j) continue; // 같은 마을 넘어가
+				
+				for(int k=1; k<=V; k++) {
+					if(i==k || j==k) continue;
+					
+					dist[j][k] = Math.min(dist[j][k], dist[j][i]+dist[i][k]);
+				}
+			}
+		}
+		
+		for(int i=1; i<=V; i++) {
+			for(int j=1; j<=V; j++) {
+				if(i==j) continue;
+				
+				if(dist[i][j] == MAXVAL || dist[j][i] == MAXVAL) continue;
+				result = Math.min(result, dist[i][j]+dist[j][i]); // 사이클 완성된 길 비교
+			}
+		}
+		
+		System.out.println(result==MAXVAL ? -1 : result);
+	}
+}


### PR DESCRIPTION
## 🔍 개요

## 📝 문제 풀이 전략 및 실제 풀이 방법

### 운동

플로이드 워셜을 사용할 수 있는가를 묻는 문제

간단하게 1번 마을에서 2번 마을로 가는 경우의 수는 여러가지가 있다.
1번에서 2번 직행으로 가던가, 1번에서 3번 마을을 거쳐 2번 마을로 가는 경유지를 거쳐 가는 경우들이 있다.

3번 마을을 거쳐 2번 마을로 가는 것도 결과적으론 1번 마을에서 2번 마을로 가는 것이기 때문에
2차원 배열을 만들어 배열[1][2]에 1번 마을에서 2번 마을로 가는 모든 경우의 수 중 거리가 가장 짧은 값을 넣어줬다.

플로이드 워셜 탐색이 끝나면 마을로 가는 최단거리가 배열에 저장돼있고 문제는 사이클을 묻고 있기 때문에 [a][b] + [b][a]가 가장 작은 값을
출력해주면 된다.

### 동계 테스트 시점 예측

외부 공기와 내부 공기를 구분해줘야겠다고 생각함
맵의 모든 공기에서 BFS 탐색하면서 벽에 닿지 않으면 내부 공기로 지정해주기로 함
과정에서 메모리 초과와, 시간 초과가 났었다.
모든 공기에서 탐색을 시작할 필요없이 무조건 외부 공기인 인덱스(0, 0)에서 탐색을 시작, 다음 이동 칸이 눈이 아니라면
모두 외부 공기 처리(-1)해주면서 외부, 내부 공기를 구분해준다.
이렇게 하면 내부 공기는 기존 값(0)으로 남아있고 외부 공기는 -1로 구분된다.
무조건 내부 공기의 값을 바꾸려고 접근하다보니 제한적인 방법에 매몰되었음

공기만 구분된다면 그 다음은 눈(1)에서 BFS 탐색하면서 외부공기와 맞닿은 횟수만 카운팅 해주면 서 눈을 지워나가면 된다.

### 도로의 개수

출력 범위보고 심상치 않다 느꼈다.
공사 중인 도로를 표시해주는 게 쉽게 떠오르지 않았다.

공사 중인 도로의 가로, 세로를 구분 후 해당 도로의 인덱스를 따로 가로, 세로 배열을 만들어서 저장한다.
학교까지 가는 길은 최단 경로라고 했기 때문에 갈 수 있는 방향은 2가지 밖에 없다.

마을 크기의 2차원 배열을 만들고 배열에 해당 인덱스로 갈 수 있는 경우의 수를 저장해준다. dp[i][j] = dp[i-1][j] + dp[i][j-1];
저장할 때 해당 인덱스의 가로, 세로가 공사 중인지 가로, 세로 배열에서 확인해주며 공사 중이라면 경우의 수를 다시 빼줌

해당 작업을 반복해주면 학교의 위치에 최단 경로의 개수가 저장된다.
https://eco-dev.tistory.com/entry/Java-%EB%B0%B1%EC%A4%80-1577-%EB%8F%84%EB%A1%9C%EC%9D%98-%EA%B0%9C%EC%88%98

## 🧐 참고 사항
ex) 이런 이런 이유로 못 풀었습니다ㅜㅜ, 이런 문제를 풀 때 좋은 참고 블로그를 밑에 링크할게요!, 등등 ...

## 📄 Reference
[참고 블로그 제목이나 내용?](블로그 링크)

ex) [깃허브 이슈, PR 템플릿 작성 할 때 참고](https://soft.plusblog.co.kr/66)
