### PR TITLE
김영후 57주차

### DIFF
--- a/hoo/week50s/57Week/Main_14945_불장난.java
+++ b/hoo/week50s/57Week/Main_14945_불장난.java
@@ -1,0 +1,37 @@
+package SSAFY.study.algo.week50s.week57;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+
+public class Main_14945_불장난 {
+
+    static int N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        calcCases();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+    }
+
+    static void calcCases() {
+        int[][] dpArr = new int[N+1][N+1];
+        dpArr[2][1] = 2;
+        for (int i = 3; i <= N; i++) {
+            for (int j = 1; j < i; j++) {
+                dpArr[i][j] = (dpArr[i-1][j] * 2 + dpArr[i-1][j-1] + dpArr[i-1][j+1]) % 10_007;
+            }
+        }
+        int answer = 0;
+        for (int i = 1; i < N; i++) answer = (answer + dpArr[N][i]) % 10_007;
+        System.out.println(answer % 10_007);
+    }
+
+}

--- a/hoo/week50s/57Week/Main_16509_장군.java
+++ b/hoo/week50s/57Week/Main_16509_장군.java
@@ -1,0 +1,76 @@
+package SSAFY.study.algo.week50s.week57;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_16509_장군 {
+
+    static int[][] board;   // 10x9 크기 장기판
+    static int R1, C1, R2, C2;  // 1: 상, 2: 왕
+
+    public static void main(String[] args) throws IOException {
+        init();
+        doKoreanChess();
+    }
+
+    static void init() throws IOException {
+        board = new int[10][9];
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        R1 = Integer.parseInt(st.nextToken());
+        C1 = Integer.parseInt(st.nextToken());
+        st = new StringTokenizer(br.readLine());
+        R2 = Integer.parseInt(st.nextToken());
+        C2 = Integer.parseInt(st.nextToken());
+    }
+
+    static void doKoreanChess() {
+        int[] dirRow = new int[] {-1, -1, -1, 0, 1, 1, 1, 0}; // 좌상 상 우상 우 우하 하 좌하 좌
+        int[] dirCol = new int[] {-1, 0, 1, 1, 1, 0, -1, -1};
+        int[][] dirSang = new int[][] {{1, 0, 0}, {1, 2, 2}, {3, 2, 2}, {3, 4, 4}, {5, 4, 4}, {5, 6, 6}, {7, 6, 6}, {7, 0, 0}}; // 상이 진행하는 방향
+
+        Queue<int[]> q = new ArrayDeque<>();
+        q.offer(new int[] {R1, C1, 0});
+        boolean[][] isVisited = new boolean[10][9];
+        isVisited[R1][C1] = true;
+
+        int[] now;
+        while (!q.isEmpty()) {
+            now = q.poll();
+            if (now[0] == R2 && now[1] == C2) { // 상이 왕을 잡은 경우
+                System.out.println(now[2]);
+                return;
+            }
+
+            int nextRow, nextCol;
+            boolean isBlocked;
+            for (int ds = 0; ds < 8; ds++) {    // 상이 이동할 수 있는 8가지 경로에 대해
+                isBlocked = false;
+                nextRow = now[0];
+                nextCol = now[1];
+                for (int d = 0; d < 3; d++) {   // 그 경로로 3칸을 이동
+                    nextRow += dirRow[dirSang[ds][d]];
+                    nextCol += dirCol[dirSang[ds][d]];
+                    if (d != 2 && nextRow == R2 && nextCol == C2) isBlocked = true; // 이동 중간에 왕을 만나면 그 길은 막힌 길임
+                }
+                if (isBlocked || isOuted(nextRow, nextCol) || isVisited[nextRow][nextCol]) continue;    // 길이 막혔거나 범위 밖으로 나가거나 이미 방문한 곳이면 건너 뜀
+                q.offer(new int[] {nextRow, nextCol, now[2]+1});
+                isVisited[nextRow][nextCol] = true;
+            }
+        }
+
+        System.out.println(-1);
+    }
+
+    static boolean isOuted(int row, int col) {
+        if ((0 <= row && row < 10) && (0 <= col && col < 9)) return false;
+
+        return true;
+    }
+
+}

--- a/hoo/week50s/57Week/Main_17404_RGB거리2.java
+++ b/hoo/week50s/57Week/Main_17404_RGB거리2.java
@@ -1,0 +1,55 @@
+package SSAFY.study.algo.week50s.week57;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_17404_RGB거리2 {
+
+    static int N;
+    static int[][] houses;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        calcMinCost();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        houses = new int[N][3];
+        StringTokenizer st;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 3; j++) houses[i][j] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    static void calcMinCost() {
+        int INF = 1_000 * 1_000;
+        int minCost = INF;
+        int[][] dpArr;
+        for (int i = 0; i < 3; i++) {   // 첫 번째 집 R, G, B인 경우로 나눠서 계산
+            dpArr = new int[N][3];
+            dpArr[0][i] = houses[0][i];
+            for (int j = 0; j < 3; j++) if (i != j) dpArr[0][j] = INF;    // 선택된 색깔 아니면 INF로 초기화
+
+            dpArr = calcCost(dpArr);
+            dpArr[N-1][i] = INF;    // 1번 집과 N번 집은 같은 색으로 칠하면 안됨.
+            for (int j = 0; j < 3; j++) minCost = Math.min(minCost, dpArr[N-1][j]);
+        }
+        System.out.println(minCost);
+    }
+
+    static int[][] calcCost(int[][] dpArr) {
+        for (int i = 1; i < N; i++) {
+            dpArr[i][0] = Math.min(dpArr[i-1][1], dpArr[i-1][2]) + houses[i][0];
+            dpArr[i][1] = Math.min(dpArr[i-1][0], dpArr[i-1][2]) + houses[i][1];
+            dpArr[i][2] = Math.min(dpArr[i-1][0], dpArr[i-1][1]) + houses[i][2];
+        }
+
+        return dpArr;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #313 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 장군
행, 열의 8방을 나타내는 배열을 이용해 상이 움지직이는 8가지의 경로를 표현했습니다. 이는 상이 움직이는 8가지 경로에 대해 총 3칸을 움직이며 해당 경로를 왕이 가로막고 있는 지 여부를 판별하기 위함입니다.
이렇게 표현을 한 후에는 단순히 bfs를 돌며 상이 왕에게 도달할 수 있는 지만 체크하면 되는 너비우선탐색 문제였습니다.

+ 불장난
첫 도전은 bfs로 했고, 보기 좋게 메모리 초과를 받았습니다. 아마 아래 아래, 아래 오른, 오른 아래, 오른 오른 4가지를 100번 반복하는 거라 꽤 큰 숫자가 필요한 것 같습니다. 시간과 공간복잡도를 따지기 조금 어렵게 느껴져 그냥 큰 값이겠구나 하고 다른 풀이법을 찾게 되었습니다. 이때 메모이제이션을 떠올리긴 했지만, 일단 규칙성을 찾아서 해결해보고자 했습니다.
그렇게 다음 도전해본 풀이법이 기웅이를 기준으로 민수가 움직이는 경우를 찾는 것이었습니다. 정말 단순하게 기웅이를 한 칸에 고정해뒀을 때 민수가 움직일 수 있는 경우를 카운트해보는 것이었는데요, 복잡한 경우를 떠올리기가 힘들어 모든 값을 고려해주지는 못해 실패했습니다.
결국 메모이제이션으로 방향을 잡고 생각해봤지만 떠오르지 않았습니다. 다른 사람들의 풀이를 참고하게 되었는데, 계산을 하는 기준 자체가 생각도 못한 방법이었습니다. 둘 사이의 '거리'를 기준으로 하여 계산을 수행해주는 방법인데요, 둘 사이의 거리가 유지되는 ((아래 아래), (대각 대각)) 경우가 두 가지, 거리가 좁아지는 경우((대각 아래))가 한 가지, 거리가 멀어지는 경우((아래 대각))이 한 가지 있음을 이용하는 방법이었습니다. 이를 통해 일반식을 각 층에서 두 사람 간의 거리에 대해 적용, dp[층][거리] = dp[층-1][거리]*2 + dp[층-1][거리+1] + dp[층-1][거리-1]을 통해 이전 층에서의 거리 별 경우의 수를 더해가는 방식으로 풀이가 가능했습니다.
이건 아마 코테에서 마주쳤다면 절대 못풀었을 것 같습니다. 어느 관점에서 일반식을 적용할 지에 대해 생각을 깊게 해봐야함을 알려주는 문제였습니다.

+ RGB 거리2
틀 자체는 RGB 거리와 같은 문제이지만, 1번 집과 N번 집의 색깔이 같으면 안된다는 조건이 있었습니다. 이 조건을 처리해주기 위한 방법을 생각해보았을 때, 1번 집에 어떤 색을 칠해줄 지 정해주면 되겠다는 생각이 들었습니다.
그리하여 1번 집을 각각 R, G, B로 칠했을 때 마지막 집까지 동적 계획법을 통해 계산을 해준 후, 1번 집을 칠한 색깔에 해당하는 비용은 INF로 갱신하여 최솟값에 포함될수 없게 해주어 조건을 처리했습니다.

## 🧐 참고 사항


## 📄 Reference
