### PR TITLE
김영후 58주차

### DIFF
--- a/hoo/week50s/58Week/Main_14284_간선이어가기2.java
+++ b/hoo/week50s/58Week/Main_14284_간선이어가기2.java
@@ -1,0 +1,90 @@
+package SSAFY.study.algo.week50s.week58;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Array;
+import java.util.*;
+
+public class Main_14284_간선이어가기2 {
+
+    static class Edge implements Comparable<Edge> {
+        int from;
+        int to;
+        int weight;
+
+        public Edge(int from, int to, int weight) {
+            this.from = from;
+            this.to = to;
+            this.weight = weight;
+        }
+
+        @Override
+        public int compareTo(Edge e1) { // 가중치 오름차순 정렬
+            return this.weight - e1.weight;
+        }
+
+        @Override
+        public String toString() { return this.from + " " + this.to + " " + this.weight; }
+    }
+
+    static int n, m, s, t;
+    static List<List<Edge>> edgeList;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        dijkstra();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        edgeList = new ArrayList<>();
+        for (int i = 0; i < n+1; i++) edgeList.add(new ArrayList<>());
+
+        int from, to, weight;
+        for (int i =0; i < m ;i++) {
+            st = new StringTokenizer(br.readLine());
+            from = Integer.parseInt(st.nextToken());
+            to = Integer.parseInt(st.nextToken());
+            weight = Integer.parseInt(st.nextToken());
+            edgeList.get(from).add(new Edge(from, to, weight)); // 무방향 그래프이므로 양방향 다 추가
+            edgeList.get(to).add(new Edge(to, from, weight));
+        }
+        st = new StringTokenizer(br.readLine());
+        s = Integer.parseInt(st.nextToken());
+        t = Integer.parseInt(st.nextToken());
+    }
+
+    static void dijkstra() {
+        int[] weights = new int[n+1];   // s에서 1~n까지 가는 가장 적은 가중치 저장
+        Arrays.fill(weights, 100_000 * 100);    // 간선 수 최댓값 * 가중치 최댓값으로 초기화
+        weights[s] = 0; // 자기 자신으로 가는 가중치는 0
+
+        PriorityQueue<Edge> pq = new PriorityQueue<>();
+        Edge initEdge;
+        for (int i = 0; i < edgeList.get(s).size(); i++) {  // pq에 시작점의 간선들 넣어주며 연결된 정점까지 가중치 값 갱신
+            initEdge = edgeList.get(s).get(i);
+            pq.offer(initEdge);
+            weights[initEdge.to] = initEdge.weight;
+        }
+
+        Edge now;
+        while (!pq.isEmpty()) {
+            now = pq.poll();
+
+            List<Edge> nextEdgeList = edgeList.get(now.to);
+            for (Edge next : nextEdgeList) {
+                if (weights[next.to] > weights[next.from] + next.weight) {
+                    weights[next.to] = weights[next.from] + next.weight;
+                    pq.offer(next);
+                }
+            }
+        }
+
+        System.out.println(weights[t]);
+    }
+
+}

--- a/hoo/week50s/58Week/Main_2589_보물섬.java
+++ b/hoo/week50s/58Week/Main_2589_보물섬.java
@@ -1,0 +1,78 @@
+package SSAFY.study.algo.week50s.week58;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_2589_보물섬 {
+
+    static int r, c;
+    static String[] map;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        int[][] distances = new int[r*c+1][r*c+1];  // 각 칸에 번호 부여하여 각 칸에서 각 칸까지 거리 저장
+        for (int i = 0; i < r*c+1; i++) Arrays.fill(distances[i], -1);
+
+        int maxDistance = 0;
+        for (int i = 0; i < r; i++) {
+            for (int j = 0; j < c; j++) {
+                if (map[i].charAt(j) == 'W') continue;
+                maxDistance = calcDistances(i, j, distances, maxDistance);
+            }
+        }
+//        for (int i = 0; i < distances.length; i++) System.out.println(i + " " + Arrays.toString(distances[i]));
+        System.out.println(maxDistance);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        map = new String[r];
+        for (int i = 0; i < r; i++) map[i] = br.readLine();
+    }
+
+    static int calcDistances(int startRow, int startCol, int[][] distances, int maxDistance) {
+        Queue<int[]> q = new ArrayDeque<>();
+        boolean[][] isVisited = new boolean[r][c];    // 현재 시작 점에서 재방문 방지할 때 쓸 배열
+        q.offer(new int[] {startRow, startCol, 0});
+        isVisited[startRow][startCol] = true;
+
+        int[] dirRow = new int[] {-1, 1, 0, 0}; // 상 하 좌 우
+        int[] dirCol = new int[] {0, 0, -1, 1};
+        int[] now;
+//        System.out.println(startRow + " " + startCol);
+//        System.out.println(startRow*c + startCol + 1);
+        while (!q.isEmpty()) {
+            now = q.poll();
+
+//            if (distances[(startRow*c)+(startCol+1)][(now[0]*c)+(now[1]+1)] != -1) continue;    // 이미 거리 측정이 된 땅은 건너 뜀
+            distances[(startRow*c)+(startCol+1)][(now[0]*c)+(now[1]+1)] = now[2];   // 서로의 거리 저장
+            distances[(now[0]*c)+(now[1]+1)][(startRow*c)+(startCol+1)] = now[2];
+            maxDistance = Math.max(maxDistance, now[2]);
+
+            int nextRow, nextCol;
+            for (int d = 0; d < 4; d++) {
+                nextRow = now[0] + dirRow[d];
+                nextCol = now[1] + dirCol[d];
+                if (isOuted(nextRow, nextCol) || isVisited[nextRow][nextCol] || map[nextRow].charAt(nextCol) == 'W') continue;
+                q.offer(new int[] {nextRow, nextCol, now[2]+1});
+                isVisited[nextRow][nextCol] = true;
+            }
+        }
+
+        return maxDistance;
+    }
+
+    static boolean isOuted(int row, int col) {
+        if ((0 <= row && row < r) && (0 <= col && col < c)) return false;
+        return true;
+    }
+
+}

--- a/hoo/week50s/58Week/Main_7490_0만들기.java
+++ b/hoo/week50s/58Week/Main_7490_0만들기.java
@@ -1,0 +1,84 @@
+package SSAFY.study.algo.week50s.week58;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+
+public class Main_7490_0만들기 {
+
+    static PriorityQueue<String> formulaPq;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        formulaPq = new PriorityQueue<>();
+        StringBuilder sb = new StringBuilder();
+        int inputNumber;
+        for (int t = 0; t < T; t++) {
+            inputNumber = Integer.parseInt(br.readLine());
+            makeFormula("", 1, inputNumber);
+
+            while (!formulaPq.isEmpty()) sb.append(formulaPq.poll()).append("\n");  // pq에 쌓인 수식 string builder에 삽입
+            sb.append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    static void makeFormula(String formula, int now, int end) {  // formula: 이때까지 만들어진 식, now: 지금 숫자, end: 끝 숫자
+        if (now == end) {   // 기저, 끝 숫자에 도달한 경우
+            formula += String.valueOf(end);
+            if (isFormulaZero(formula)) formulaPq.offer(formula);
+
+            return;
+        }
+
+        formula += String.valueOf(now);
+        makeFormula(formula + "+", now+1, end);
+        makeFormula(formula + "-", now+1, end);
+        makeFormula(formula + " ", now+1, end);
+    }
+
+    static boolean isFormulaZero(String formula) {  // 만들어진 식이 0인지 판별하는 함수
+//        System.out.println(formula);
+        int result = 0;
+        int temp = 0;
+        int multiplier = 1; // +, -에 따라 달라질 부호
+        for (int i = 0; i < formula.length(); i++) {
+            char nowChar = formula.charAt(i);
+            switch (nowChar) {
+                case '+':
+                    result = result + (multiplier * temp);    // 이전까지 결과 계산 후
+                    temp = 0;
+                    multiplier = 1;  // 부호 수정
+                    break;
+                case '-':
+                    result = result + (multiplier * temp);
+                    temp = 0;
+                    multiplier = -1;
+                    break;
+                case ' ':   // 빈칸은 건너 뜀
+                    break;
+                default:    // 숫자인 경우
+                    temp = Integer.parseInt(String.valueOf(temp) + String.valueOf(nowChar));
+                    break;
+            }
+//            System.out.println(nowChar);
+//            System.out.println(result);
+//            System.out.println(temp);
+//            System.out.println("--------------");
+        }
+        result = result + (multiplier * temp);
+        if (result == 0) {
+//            System.out.println(formula);
+//            System.out.println(result);
+//            System.out.println(temp);
+            return true;
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #320 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 간선 이어가기 2
문제에서 설명을 좀 꼬아서 해놔서 그렇지 그냥 start 지점에서 end 지점까지 가장 최소의 가중치로 갈 수 있는 경우의 가중치를 계산하는 문제였습니다. 
전형적인 다익스트라 문제였으므로 다익스트라를 이용해 출발 점에서 각 지점까지 최소 가중치 계산하고 도착 지점까지의 가중치를 출력하는 것으로 해결했습니다.

+ 보물섬
무식하게 모든 지점에서 bfs를 돌며 거리를 구했습니다. 이때 땅 간의 거리를 측정할 때마다 max 값을 갱신해주었고 모든 땅에 대해 거리 판별이 끝나면 max값을 출력해주어 해결했습니다.
최적화를 하고 싶은데 방법이 바로는 떠오르지 않아 그냥 무식하게 푼 그대로 뒀습니다.

+ 0 만들기
TC의 최대 개수가 9개, N의 최댓값이 9이므로 브루트포스 형식의 재귀를 구현해도 9*(3^8)만에 해결이 가능해 그렇게 해결했습니다. 
매 재귀에서 현재 숫자와 +, -, " "를 수식에 추가해주었고, 마지막 숫자에 도달하는 것을 기저 조건으로 잡았습니다. 기저 도달 시, 해당 수식의 결과 값이 0인 지를 판별하고 값이 0이라면 사전 순 정렬을 위해 전역 자료형 PriorityQueue에 offer해줍니다. 
매 TC마다 pq가 빌 때까지 StringBuilder에 append 해준 후 출력하면 정답이 됩니다.

## 🧐 참고 사항


## 📄 Reference
