### PR TITLE
김영후_60주차

### DIFF
--- a/hoo/60Week/Main_12891_DNA비밀번호.java
+++ b/hoo/60Week/Main_12891_DNA비밀번호.java
@@ -1,0 +1,71 @@
+package SSAFY.study.algo.week60;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class Main_12891_DNA비밀번호 {
+
+    static int S, P;
+    static String dnaString;
+    static Map<Character, Integer> needACGT;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        countPossible();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        S = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+        dnaString = br.readLine();
+        needACGT = new HashMap<>();
+        st = new StringTokenizer(br.readLine());
+        needACGT.put('A', Integer.parseInt(st.nextToken()));
+        needACGT.put('C', Integer.parseInt(st.nextToken()));
+        needACGT.put('G', Integer.parseInt(st.nextToken()));
+        needACGT.put('T', Integer.parseInt(st.nextToken()));
+    }
+
+    static void countPossible() {
+        Map<Character, Integer> acgtMap = new HashMap<>();  // 현재 윈도우 안에 있는 A, C, G, T 개수 카운트
+        acgtMap.put('A', 0);
+        acgtMap.put('C', 0);
+        acgtMap.put('G', 0);
+        acgtMap.put('T', 0);
+        int fulfillCount = 0;   // A, C, G, T 만족하는 개수 카운트
+        for (char key : needACGT.keySet()) if (needACGT.get(key) == 0) fulfillCount++;  // 0개 필요한 문자들은 미리 카운트+1
+
+        char outChar, inChar;
+        for (int i = 0; i < P; i++) {   // 첫 글자부터 P개까지 a, c, g, t 개수 저장
+            inChar = dnaString.charAt(i);
+            acgtMap.put(inChar, acgtMap.get(inChar)+1);
+            if (acgtMap.get(inChar).equals(needACGT.get(inChar))) fulfillCount++;    // 딱 조건 충족 개수가 됐을 때 fullfillCount +1
+        }
+        int count = (fulfillCount == 4)? 1:0;   // 제일 첫 윈도우가 조건 충족하는 지 여부에 따라 0 or 1로 초기화
+
+        for (int i = P; i < S; i++) {
+            inChar = dnaString.charAt(i);
+            acgtMap.put(inChar, acgtMap.get(inChar)+1);
+            if (acgtMap.get(inChar).equals(needACGT.get(inChar))) fulfillCount++;    // 딱 조건 충족 개수가 됐을 때 fullfillCount +1
+//            System.out.println(acgtMap);
+//            System.out.println(fulfillCount);
+            outChar = dnaString.charAt(i-P);
+            if (acgtMap.get(outChar).equals(needACGT.get(outChar))) fulfillCount--;  // 조건 충족 카운트보다 딱 한 개만큼 작아졌다면 fullfillCount -1
+            acgtMap.put(outChar, acgtMap.get(outChar)-1);
+//            System.out.println(acgtMap);
+//            System.out.println(fulfillCount);
+//            System.out.println("=============");
+
+            if (fulfillCount == 4) count++; // 조건 모두 충족한다면 count+1
+        }
+
+        System.out.println(count);
+    }
+
+}

--- a/hoo/60Week/Main_1662_압축.java
+++ b/hoo/60Week/Main_1662_압축.java
@@ -1,0 +1,41 @@
+package SSAFY.study.algo.week60;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main_1662_압축 {
+
+    static int index;   // 확인할 인덱스
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String input = br.readLine();
+
+        System.out.println(unzip(input));   // 재귀 함수 실행
+    }
+
+    static int unzip(String input) {
+        int length = 0;
+        while (index < input.length()) {    //
+            char current = input.charAt(index); //
+
+            if (index + 1 < input.length() &&   // 주어진 문자의 끝이 아닌 문자이면서
+                    Character.isDigit(current) && input.charAt(index + 1) == '(') { // 현재 인덱스가 숫자이며, 다음 문자가 여는 괄호인 경우
+                int k = Integer.parseInt(String.valueOf(input.charAt(index)));  // 괄호 내의 숫자 길이에 곱해줄 현재 숫자 정수화
+                index += 2; // 여는 괄호 다음 숫자부터 수행하게
+
+                length += k * unzip(input); // 괄호 내의 문자에 대해 재귀 수행, 길이를 현재 숫자와 곱해줌
+            } else if (current == ')') {    // 기저, 닫는 괄호인 경우 다음 인덱스로 늘려주고 지금까지 센 길이 반환
+                index++;
+                return length;
+            } else {    // 다음 문자가 괄호 여는 게 아닌 경우이며 숫자라면 길이+1, 인덱스+1
+                length++;
+                index++;
+            }
+        }
+
+        return length;  // 최종 길이 반환
+    }
+
+}

--- a/hoo/60Week/Main_2206_벽부수고이동하기.java
+++ b/hoo/60Week/Main_2206_벽부수고이동하기.java
@@ -1,0 +1,93 @@
+package SSAFY.study.algo.week50s.week60;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_2206_벽부수고이동하기 {
+
+    static class Player {
+        int row;
+        int col;
+        int dist;   // 움직인 거리
+        boolean broke;  // 벽 부쉈는 지 여부, 0은 안부심 1은 부심
+
+        public Player(int row, int col, int dist, boolean broke) {
+            this.row = row;
+            this.col = col;
+            this.dist = dist;
+            this.broke = broke;
+        }
+    }
+
+    static int N, M;
+    static int[][] map;
+    static int shortestDist;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        bfs();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        map = new int[N][M];
+        String input;
+        for (int i = 0; i < N; i++) {
+            input = br.readLine();
+            for (int j = 0; j < M; j++) map[i][j] = Integer.parseInt(String.valueOf(input.charAt(j)));
+        }
+        shortestDist = N*M + 1;
+    }
+
+    static void bfs() {
+        Queue<Player> q = new ArrayDeque<>();
+        boolean[][][] isVisited = new boolean[N][M][2]; // 0: 벽 안부순 경우, 1: 벽 부순 경우
+        q.offer(new Player(0, 0, 0, false));
+        isVisited[0][0][0] = true;;
+
+        int[] dirRow = new int[] {-1, 0, 1, 0}; // 상 우 하 좌
+        int[] dirCol = new int[] {0, 1, 0, -1};
+        Player now;
+        int INF = N*M + 1;
+        int answer = INF;
+        while (!q.isEmpty()) {
+            now = q.poll();
+            if (now.row == N-1 && now.col == M-1) { // 도착점 도달했을 경우
+                answer = Math.min(answer, now.dist);
+                continue;
+            }
+
+            int nextRow, nextCol;
+            for (int d = 0; d < 4; d++) {
+                nextRow = now.row + dirRow[d];
+                nextCol = now.col + dirCol[d];
+                if (isOuted(nextRow, nextCol)) continue;    // 범위 밖이면 건너 뜀
+                if (isVisited[nextRow][nextCol][now.broke? 1:0]) continue;    // 아무 경우나 이미 방문했다면 건너 뜀
+                if (map[nextRow][nextCol] == 1) {   // 다음 칸이 벽인 경우
+                    if (now.broke) continue;    // 벽 이미 한 번 부순 경우는 건너 뜀
+                    q.offer(new Player(nextRow, nextCol, now.dist+1, true));
+                    isVisited[nextRow][nextCol][1] = true;
+                } else {    // 다음 칸 벽 아닌 경우
+                    q.offer(new Player(nextRow, nextCol, now.dist+1, now.broke));
+                    isVisited[nextRow][nextCol][now.broke? 1:0] = true;
+                }
+            }
+        }
+
+        System.out.println((answer == INF)? -1:answer+1);
+    }
+
+    static boolean isOuted(int row, int col) {
+        if ((0 <= row && row < N) && (0 <= col && col < M)) return false;
+        return true;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #336 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 벽 부수고 이동하기
제 풀이의 틀은 너비우선탐색입니다. 하지만 방문 체크 배열을 3차원으로 두어 벽을 부순 Player, 벽을 부수지 않은 Player의 방문을 따로 체크해주었습니다. 벽의 부숨 여부는 Player에 boolean 필드로 두어 저장했고, while문 내에서의 조건 처리는
  1. 맵의 범위 내이고
  2. 현재 부숨 여부에 따라 방문하지 않은 곳인 칸에 대해
  3. 현재 칸이 벽이라면
  3-1. Player가 아직 벽을 부수지 않았다면 큐에는 벽은 부순 Player를 저장하며 
  3-2. 벽을 부순 Player 방문 배열 체크
  4. 현재 칸이 빈칸이라면
  4-1. 큐에 Player를 넣어줌
  4-2. 방문 배열은 Player의 벽 부숨 여부에 따라 체크

  와 같이 해주었습니다.

+ DNS 비밀번호
슬라이딩 윈도우를 활용했습니다. 맨 처음 P길이 만큼의 문자에 대해 A, C, G, T 당 카운트를 저장해주고, 윈도우를 한 칸씩 오른쪽으로 움직이며 윈도우에서 빠진 문자는 이전 카운트-1, 윈도우에 새로 들어온 문자는 카운트+1을 해주었습니다. 
이와 함께 윈도우가 품은 문자열이 올바른 비밀번호인 지를 판별하기 위해 fufilledCount라는 변수를 두었는데요, 윈도우마다 이 변수의 값이 4인 경우에는 올바른 비밀번호로 판단하여 정답 카운트를 +1 해주었습니다. 이때 fulfilledCount는 윈도우에 들어오는 문자의 카운트가 맨 처음 주어진 문자당 필요한 개수와 같아질 때는 +1을, 윈도우에서 나가는 문자가 나가는 시점에 보았을 때 필요한 개수와 같았다면 -1을 해주는 식으로 관리했습니다.
저는 이 문제에서 A, C, G, T의 각 카운트를 Map에 <Character, Integer> 형태로 저장해주었습니다. 이와 관련해 문제를 틀리게 되었는데요, map의 get(key)을 통해 가져온 value가 Wrapper class인데 ==으로 비교를 하고 있어서 틀리게 되었습니다.
이를 인지하지 못하고 로직의 올바름에 대한 테스트를 위해 매 윈도우마다 map의 key마다의 value가 필요한 개수보다 >= 이면 올바른 비밀번호로 인식하게 하는 코드는 정답을 받았는데요, 이는 Java가 >, <, >=, <=과 같은 비교 연산자를 사용할 때는 Wrapper class를 자동으로 unboxing해주기 때문에 의도한 바와 같이 코드가 동작해서 정답을 받은 것이었습니다. 정리하자면,
  1. Map.get(key)의 결과는 primitive type이 아닌 Wrapper class이다. 비교할 때 주의하자.
  2. Java에서 >, <, >=, <= 연산자를 사용할 때는 피연산자에 자동으로 unboxing이 수행된다.

  와 같은 내용이 제가 이 문제를 통해 경험한 사실입니다.

+ 압축
재귀 작성하느라 머리 터질뻔했습니다. 괄호가 ( ( ( ) ) )과 같이 한 번의 중첩으로 끝나는 입력은 고려를 했는데, ( ( ) ( ) ) 과 같이 한 괄호 내에 여러 개가 떨어져있는 경우에 대한 처리가 잘 되지 않았습니다. 이를 해결하기 위해 기존에 매개변수로 startIndex를 받고 for문으로 startIndex부터 기저까지 순회를 하는 코드에서, index를 전역으로 분리하고 재귀이지만 시작하는 인덱스는 전역으로 관리하게끔 코드를 수정하여 해결할 수 있었습니다. 이때 재귀 당 처리해준 조건은
  1. 현재 문자가 숫자이며 다음 문자가 '('일 때 => 재귀를 들어가는 진입점입니다. 현재 문자는 재귀의 반환값에 곱해줄 값이고, 재귀는 '(' 뒤의 문자부터 수행하게끔 인덱스를 +2해줍니다. 그리고 재귀의 반환값에 현재의 문자를 곱한 값을 길이 카운트에 더해줍니다.
  2. 현재 문자가 ')'일 때 => 기저조건입니다. 이때는 인덱스를 +1해주며 지금까지 카운트했던 문자열의 길이를 반환합니다.
  3. 현재 문자가 숫자일 때 => 괄호 안의 숫자?문자열?의 길이를 카운트합니다. 그와 함께 인덱스도 +1해줍니다.

  와 같습니다. 이런 조건을 품은 반복문을 문자 내의 모든 문자에 대해 수행해주고 최종 길이 카운트를 정답으로 반환해주었습니다.

## 🧐 참고 사항

## 📄 Reference
