### PR TITLE
Hoo

### DIFF
--- a/hoo/week60s/62Week/Main_1398_동전문제.java
+++ b/hoo/week60s/62Week/Main_1398_동전문제.java
@@ -1,0 +1,47 @@
+package SSAFY.study.algo.week60s.week62;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main_1398_동전문제 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        for (int t = 0; t < T; t++) {
+            long price = Long.parseLong(br.readLine());    // 초콜릿의 가격
+            sb.append(calcCoinCount(price)).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    static int calcCoinCount(long price) {
+        int[] needCoins = makeNeedCoins();    // 1 ~ 99원까지의 필요 동전 최소 개수를 저장하고 있는 배열
+        int coinCount = 0;
+        while (price != 0) {    // 동전의 가치는 100의 거듭제곱을 규칙으로 가지고 있음. => 100의 거듭제곱이 규칙이므로 가격 역시 그 범위로 나누어 각각의 범위에 대해 판단 가능
+            coinCount += needCoins[(int) (price % 100)];    // 현재 가격에 100의 거듭제곱을 나눈 나머지에 사용할 동전 카운트
+            price /= 100;   // 다음 거듭 100의 거듭 제곱 단위 파악 위해 100으로 나누어줌
+        }
+
+        return coinCount;
+    }
+
+    static int[] makeNeedCoins() {  // 1~99원까지 1, 10, 25원짜리 동전을 최소 개수로 사용하여 만들 수 있는 경우의 수 계산
+        int[] needCoins = new int[100];
+        for (int i = 0; i < 100; i++) {
+            if (i < 10) needCoins[i] = i;
+            else if (i >= 10 && i < 25) needCoins[i] = Math.min(needCoins[i-10], needCoins[i-1]) + 1;   // 10원짜리 쓰는 것과 1원짜리 쓰는 것 비교
+            else if (i >= 25) {
+                needCoins[i] = Math.min(needCoins[i-25], needCoins[i-10]) + 1;  // 먼저 25원짜리 하나 쓰는 것과 10원짜리 쓰는 것을 비교
+                needCoins[i] = Math.min(needCoins[i], needCoins[i-1]+1);    // 그 후 1원짜리 쓰는 것과 비교
+            }
+
+        }
+
+        return needCoins;
+    }
+
+}

--- a/hoo/week60s/62Week/Main_22866_탑보기.java
+++ b/hoo/week60s/62Week/Main_22866_탑보기.java
@@ -1,0 +1,69 @@
+package SSAFY.study.algo.week60s.week62;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class Main_22866_탑보기 {
+
+    static int N;
+    static int[] buildings;
+    static int[] canSee;
+    static int[] minCanSeeIndex;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        countCanSee();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        buildings = new int[N + 1]; // 인덱스를 1부터 사용
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) buildings[i] = Integer.parseInt(st.nextToken());
+        canSee = new int[N + 1];    // 각 빌딩이 볼 수 있는 빌딩 수 저장할 배열
+        minCanSeeIndex = new int[N + 1];    // 볼 수 있는 빌딩들 중 인덱스가 가장 작은 빌딩 저장할 배열
+        Arrays.fill(minCanSeeIndex, -100_000); // 초기값 변경
+    }
+
+    static void countCanSee() {
+        Stack<Integer> canSeeLeftStack = new Stack<>(); // 현재 시점에서 볼 수 있는 왼쪽 빌딩들 인덱스 저장한 스택
+        Stack<Integer> canSeeRightStack = new Stack<>(); // 볼 수 있는 오른쪽 빌딩들 인덱스 저장한 스택
+
+        for (int i = 1; i <= N; i++) {
+            canSeeLeftStack = countCanSeeAtNowBuilding(canSeeLeftStack, i, true);
+        }
+        for (int i = N; i >= 1; i--) {
+            canSeeRightStack = countCanSeeAtNowBuilding(canSeeRightStack, i, false);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= N; i++) {
+            if (canSee[i] == 0) sb.append(0).append("\n");
+            else {
+                sb.append(canSee[i]).append(" ").append(minCanSeeIndex[i]).append("\n");
+            }
+        }
+        System.out.println(sb);
+    }
+
+    static Stack<Integer> countCanSeeAtNowBuilding(Stack<Integer> canSeeStack, int index, boolean isLeft) {
+        while (!canSeeStack.isEmpty() && buildings[canSeeStack.peek()] <= buildings[index]) {
+            canSeeStack.pop(); // 현재 빌딩보다 높이가 낮거나 같은 빌딩들은 제거
+        }
+        canSee[index] += canSeeStack.size(); // 현재 스택 내에 있는 빌딩 개수만큼 볼 수 있음을 표시
+        if (!canSeeStack.isEmpty()) {
+            int closestBuilding = canSeeStack.peek();
+            if (minCanSeeIndex[index] == -100_000 || Math.abs(closestBuilding - index) < Math.abs(minCanSeeIndex[index] - index)) {
+                minCanSeeIndex[index] = closestBuilding; // 볼 수 있는 빌딩 중 가장 가까운 빌딩 번호 갱신
+            }
+        }
+        canSeeStack.push(index); // 스택에 현재 빌딩 추가
+        return canSeeStack;
+    }
+
+}

--- a/hoo/week60s/62Week/Main_3980_선발명단.java
+++ b/hoo/week60s/62Week/Main_3980_선발명단.java
@@ -1,0 +1,54 @@
+package SSAFY.study.algo.week60s.week62;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main_3980_선발명단 {
+
+    static int[][] players;
+    static int maxAbilitySum;
+
+    public static void main(String[] args) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        for (int t = 0; t < T; t++) {
+            init(br);
+            setPosition(0, new boolean[11], 0);
+            sb.append(maxAbilitySum).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    static void init(BufferedReader br) throws IOException {
+        players = new int[11][11];
+        StringTokenizer st;
+        for (int i = 0; i < 11; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 11; j++) players[i][j] = Integer.parseInt(st.nextToken());
+        }
+        maxAbilitySum = 0;
+    }
+
+    static void setPosition(int nowPosition, boolean[] isSelectedPlayer, int abilitySum) { // nowPosition: 현재 설정할 포지선, isSelectedPlayer: 이미 포지션 정해진 선수인지 여부, abilities: 각 포지션 별 능력치
+        if (nowPosition == 11) {    // 기저, 모든 선수 배치가 끝난 경우
+            maxAbilitySum = Math.max(maxAbilitySum, abilitySum);
+            return;
+        }
+
+        int[] nowPlayer;
+        for (int i = 0; i < 11; i++) {
+            nowPlayer = players[i];
+            if (isSelectedPlayer[i]) continue;  // 이미 다른 포지션에 배치된 선수라면 건너 뜀
+            if (nowPlayer[nowPosition] == 0) continue;  // 현재 선수가 해당 포지션에서의 능력치가 0인 경우 배치 안함
+
+            isSelectedPlayer[i] = true;
+            setPosition(nowPosition+1, isSelectedPlayer, abilitySum + nowPlayer[nowPosition]);
+            isSelectedPlayer[i] = false;
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #352 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 동전 문제
우선 다른 사람의 발상을 참고했습니다. 그 후 해당 방법이 왜 가능한 지를 생각해보고 코드로 옮겨보았습니다.
동적 프로그래밍을 이용한 풀이를 해아할 것 같았지만, 10의 15승 까지 동전을 모두 저장해주는 게 비효율적이라는 판단을 했습니다. 하지만 첫 풀이는 그런 식으로 진행해봤고, 역시나 틀렸습니다. 그리고 다시 생각해보니 이 풀이는 어차피 O(10^15)라 시간복잡도에서 터지네요.
dp는 사용해야 하는데 시간복잡도를 더 줄일 수 있는 방법이 떠오르지 않아 그리디하게 접근해야 한다는 것을 생각해봤으나, 그리디한 접근법이 떠오르지 않았습니다. 그렇게 다른 사람들의 발상을 참고했는데, 문제에서 주어진 동전은 [1, 10, 25]의 동전에 100을 곱해주는 방식의 규칙성을 가지고 있었습니다. 그로인해 문제에서 주어진 가격을 100단위로 나누어가며 생각해봐도 되는 것이 되므로, 1 ~ 99원 사이의 가격을 [1, 10, 25]의 동전을 최소로 이용해 만들 수 있는 경우만 메모해두면 풀이가 가능해집니다.
이제 필요한 1~99원의 가격을 만드는 최소 경우의 수를 구해줍니다. 이는 단순히 1 ~ 99원을 순회하며 1 ~ 9원, 10 ~ 24원, 25 ~ 100원의 범위로 나누고, dp[i] = Math.min(dp[구해줄 가격-다른 동전 사용하는 경우]+1, dp[구해줄 가격-1]+1)의 점화식을 통해 구할 수 있습니다. 
이렇게 메모해둔 최소 동전 개수를 이용해 
  1. 현재 price를 100으로 나눈 나머지에 대한 동전의 개수를 정답에 더해줍니다.
  2. 그후 현재 price를 100으로 나누어줍니다(나눈 몫만 사용)

  의 과정을 price가 0이 되기 전까지 반복해준 것이 정답이 됩니다.

+ 선발 명단
백트래킹으로 해결했습니다. 말은 백트래킹이지만 우리가 알고 있는 순열에 지금 나열할 선수의 능력치가 0인 지를 조사하는 조건만 추가해주어 풀이했습니다. 정답은 어차피 합이므로 매개변수로는 선택된 선수들의 순서를 담은 리스트가 아닌 선수들의 능력치 합을 넘겨주었습니다.

+ 탑 보기
주어진 N이 10만이므로 순회를 한 번만 해야하며, 그 한 번의 순회에서 이전까지 값들 중 현재 값보다 큰 값들만 개수를 알고 싶다 => 스택을 이용했습니다. 왼쪽과 오른쪽에 대해 모두 개수를 세알려줘야 하므로 0 ~ N-1까지의 순회와 N-1 ~ 0까지의 순회를 하며 스택에 저장을 해오는 방식으로 볼 수 있는 탑의 개수를 카운트해줬습니다. 순회를 하며 각 건물에서
  1. 현재 건물 높이보다 높은 건물이 나올 때까지 pop()을 해준다
  2. 1번 완료 후 스택의 사이즈가 현재 건물에서 해당 방향으로 볼 수 있는 건물의 개수임을 저장해준다
  3. 현재 건물을 스택에 push()해준다

  와 같은 로직을 수행해주었습니다. 이때 하나 더 다뤄줘야 헸던 것이 그 중 가장 가까운 건물 번호를 출력해주는 것입니다. 이를 위해서 가장 가까운 건물 인덱스를 저장하는 배열을 하나 더 선언, 위의 2번 과정과 함께 스택의 가장 위에 있는 건물의 인덱스를 현재 저장된 건물 인덱스와 비교해 가까운 건물이면 갱신해주는 식으로 가까운 건물을 찾아주었습니다.
  이때 저는 인덱스의 초기값을 잘못설정해주어 많이 틀렸습니다. 그래서 도대체 뭐가 잘못됐나 다른 사람 풀이를 참고해보니 초기값과 갱신을 잘못 설정해준 것임을 알아채고 수정했습니다^^

## 🧐 참고 사항


## 📄 Reference
