### PR TITLE
김영후 66주차

### DIFF
--- a/hoo/week60s/66Week/Main_1766_문제집.java
+++ b/hoo/week60s/66Week/Main_1766_문제집.java
@@ -1,0 +1,84 @@
+package SSAFY.study.algo.week60s.week66;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_1766_문제집 {
+
+    static class Problem implements Comparable<Problem> {
+        int problemNumber;
+        int prior;
+
+        public Problem(int problemNumber, int prior) {
+            this.problemNumber = problemNumber;
+            this.prior = prior;
+        }
+
+        @Override
+        public int compareTo(Problem p) {
+            return this.problemNumber - p.problemNumber;    // 문제의 난이도가 번호 순이므로, 번호 기준 오름차순 정렬
+        }
+
+        @Override
+        public String toString() { return this.problemNumber + " " + this.prior; }
+    }
+
+    static List<List<Problem>> problemList; // 해당 문제를 우선순위로 하는 문제들을 담은 리스트를 저장하고 있는 리스트
+
+    public static void main(String[] args) throws IOException {
+        int[] inCount = init(); // 문제들 리스트, 진입 차수 초기화
+        judgeOrder(inCount);
+    }
+
+    static int[] init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());   // 문제 수
+        int M = Integer.parseInt(st.nextToken());   // 주어지는 우선 순위 수
+        problemList = new ArrayList<>();
+        for (int i = 0; i <= N; i++) problemList.add(new ArrayList<>());
+
+        int[] inCount = new int[N+1];   // 각 문제 별 이전에 수행돼야하는 문제 수(진입 차수) 카운트
+        int prior, problemNo;
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            prior = Integer.parseInt(st.nextToken());   // 이번 문제 이전에 풀면 좋은 문제
+            problemNo = Integer.parseInt(st.nextToken());
+
+            problemList.get(prior).add(new Problem(problemNo, prior));
+            inCount[problemNo]++;
+        }
+
+        return inCount;
+    }
+
+    static void judgeOrder(int[] inCount) {
+        PriorityQueue<Problem> pq = new PriorityQueue<>();
+        for (int i = 1; i < inCount.length; i++) {
+            if (inCount[i] == 0) pq.offer(new Problem(i, 0));   // 우선 풀어줄 문제가 없는 문제들을 pq에 담아줌. 이들의 prior는 의미 없다는 의미에서 0으로 해줌.
+        }
+
+        int[] judgedOrder = new int[inCount.length-1];    // 순서가 결정된 문제 번호를 저장할 배열
+        int judgedOrderIndex = 0;
+
+        Problem now;
+        while (!pq.isEmpty()) {
+            now = pq.poll();
+
+            judgedOrder[judgedOrderIndex++] = now.problemNumber;  // 현재 문제의 우선 순위 문제들을 모두 해결한 문제, 순서에 적용해줌
+
+            List<Problem> nextProblemList = problemList.get(now.problemNumber); // 현재 문제를 우선 순위로 둔 문제들 리스트
+            for (Problem nextProblem : nextProblemList) {
+                inCount[nextProblem.problemNumber]--;   // 우선순위 문제 개수 하나 감소처리
+                if (inCount[nextProblem.problemNumber] == 0) pq.offer(nextProblem); // 모든 우선 순위 문제 처리한 문제는 우선 순위 큐에 삽입
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < judgedOrder.length; i++) sb.append(judgedOrder[i]).append(" ");
+        System.out.println(sb);
+    }
+
+}

--- a/hoo/week60s/66Week/Main_2580_스도쿠.java
+++ b/hoo/week60s/66Week/Main_2580_스도쿠.java
@@ -1,0 +1,87 @@
+package SSAFY.study.algo.week60s.week66;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main_2580_스도쿠 {
+
+    static int[] dirRow = new int[] {-1, 0, 1, 0};  // 상 좌 하 우
+    static int[] dirCol = new int[] {0, -1, 0, 1};
+    static int[][] board;
+    static boolean isCompleted; // 스도쿠 완성됐는 지 여부 저장하는 변수
+    static StringBuilder sb;
+
+    public static void main(String[] args) throws IOException {
+        List<int[]> blankList = init();
+        doSudoku(blankList, 0);
+        System.out.println(sb);
+    }
+
+    static List<int[]> init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        board = new int[9][9];
+        isCompleted = false;
+        sb = new StringBuilder();
+        List<int[]> blankList = new ArrayList<>();
+        StringTokenizer st;
+        for (int i = 0; i < 9; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 9; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+                if (board[i][j] == 0) blankList.add(new int[] {i, j});
+            }
+        }
+
+        return blankList;
+    }
+
+    static void doSudoku(List<int[]> blankList, int cnt) {    // 스도쿠 진행
+        if (isCompleted) return;    // 스도쿠 판 완성된 경우 함수 진행 종료
+        if (cnt == blankList.size()) {  // 모든 칸 다 채운 경우, 스도쿠 판 완성됐음을 체크 후 함수 종료
+            isCompleted = true;
+            for (int i = 0; i < 9; i++) {
+                for (int j = 0; j < 9; j++) {
+                    sb.append(board[i][j]).append(" ");
+                }
+                sb.append("\n");
+            }
+
+            return;
+        }
+
+        int[] now = blankList.get(cnt);
+        for (int n = 1; n <= 9; n++) {
+            if (!checkLine(now, n) || !checkSquare(now, n)) continue;   // 행, 열, 사각형 내에 이미 있는 숫자면 건너 뜀
+            board[now[0]][now[1]] = n;
+            doSudoku(blankList, cnt+1);  // 다음 칸에 대해 재귀 수행
+            board[now[0]][now[1]] = 0;
+        }
+
+    }
+
+    static boolean checkLine(int[] axis, int nowNumber) {
+        for (int i = 0; i < 9; i++) {
+            if (i != axis[0] && board[i][axis[1]] == nowNumber) return false;   // 지금 열 모두 체크하는데 같은 숫자 이미 있으면 거짓 반환
+            if (i != axis[1] && board[axis[0]][i] == nowNumber) return false;   // 지금 행 ~
+        }
+
+        return true;    // 조건 충족 시 참 반환
+    }
+
+    static boolean checkSquare(int[] axis, int nowNumber) {
+        int rowOffset = (axis[0] / 3) * 3;  // 정사각형의 행이 시작하는 위치
+        int colOffset = (axis[1] / 3) * 3;  // 열이 시작하는 위치
+        for (int i = rowOffset; i < rowOffset + 3; i++) {   // 정사각형의 행
+            for (int j = colOffset; j < colOffset + 3; j++) {   // 정사각형의 열
+                if (board[i][j] == nowNumber) return false; // 정사각형 내에 이미 있는 숫자면 거짓 반환
+            }
+        }
+
+        return true;    // 조건 충족 시 참 반환
+    }
+
+}

--- a/hoo/week60s/66Week/Main_9082_지뢰찾기.java
+++ b/hoo/week60s/66Week/Main_9082_지뢰찾기.java
@@ -1,0 +1,54 @@
+package SSAFY.study.algo.week60s.week66;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main_9082_지뢰찾기 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        for (int t = 0; t < T; t++) {
+            sb.append(findMine(br)).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    static int findMine(BufferedReader br) throws IOException {
+        int[] map = initMap(br);
+
+        int answer = 0;
+        for (int i = 0; i < map.length; i++) {
+            if ( i == 0 && (map[i] != 0 && map[i+1] != 0) ) {   // 제일 첫 칸인 경우, 현재 칸과 오른쪽 칸의 지뢰 숫자가 1이상이면 지뢰 확정적 개수 +1
+                map[i]--;
+                map[i+1]--;
+                answer++;
+            } else if ( i == map.length-1 && (map[i-1] != 0 && map[i] != 0) ) {  // 제일 마지막 칸인 경우, 현재 칸과 왼쪽 칸의 지뢰 숫자가 1이상이면 지뢰 확정적 개수 +1
+                map[i-1]--;
+                map[i]--;
+                answer++;
+            } else if ( (1 <= i && i < map.length-1) && (map[i-1] != 0 && map[i] != 0 && map[i+1] != 0) ) {    // 그 외 다른 칸들, 좌 바로 아래 우를 모두 살펴서 모든 칸 지뢰 개수 1이상이면 지뢰 확정적 개수 +1
+                map[i-1]--;
+                map[i]--;
+                map[i+1]--;
+                answer++;
+            }
+        }
+
+        return answer;
+    }
+
+    static int[] initMap(BufferedReader br) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        int[] map = new int[N];  // map의 0에는 숫자, 1에는 문자 저장
+        String inputRow = br.readLine();
+        for (int i = 0; i < N; i++) map[i] = Integer.parseInt(String.valueOf(inputRow.charAt(i)));
+        inputRow = br.readLine();   // 다음 줄은 필요 없어서 입력 받기만 하고 방치
+
+        return map;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #379 

## ✔️ 문제 풀이 진행 사항
올완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 문제집
문제 당 선행으로 풀어야 하는 문제가 정해져있음 -> 위상 정렬을 떠올렸습니다. 그런데 여기서 조건이 하나 더 추가됩니다. 쉬운 순으로 풀이를 해야한다는 건데요, 문제 번호가 낮을 수록 쉽다고 합니다. -> 우선 순위 큐를 떠올렸습니다.
만약 같은 우선 순위를 갖는 문제가 생긴다면(예를 들어 문제 하나를 해결함으로써, 그 문제를 우선순위로 갖고 있던 문제들이 세 문제라고 쳤을 때 세 문제 모두 우선 순위 문제를 해결한 상황), 이때는 쉬운 순의 정렬이 한 번 더 필요하다는 겁니다. 일반적인 위상 정렬에서는 큐를 사용하지만, 이를 우선 순위 큐로 바꾸어 적용해준다면, 같은 우선 순위를 갖게 되는(즉 당장 다음에 풀) 문제들을 번호 순으로 정렬할 수 있습니다.
기존 알고리즘에 적절한 자료구조를 녹여내, 의도하는 로직을 효율적으로 구현하는 사고에 연습이 되는 문제였습니다.


+ 스도쿠
백트래킹의 대표 예제격 문제라고 생각합니다. 스도쿠의 조건을 만족하는 숫자를 각 칸에 넣어보며 모든 경우를 다 탐색해야 합니다.
저는 처음에 시간초과를 겪었는데요, 이는 isChecked[] 배열을 통해 어느 빈칸에 숫자를 대입했는 지 여부를 저장했기 때문입니다. 이렇게 하면 한 번 숫자를 넣은 칸이라면 그 숫자가 스도쿠 조건에는 부합했지만 전체적인 스도쿠를 완성하는 데에는 잘못된 숫자일 때, 돌아가서 다시 숫자를 넣어볼 수가 없습니다. 모든 칸이 빈칸인 경우에 무한 루프가 도는 것을 확인함으로써 이를 발견했고, 돌아가서 다시 체크를 할 수 있도록 isChecked[] 배열을 지워줌으로써 해결했습니다.


+ 지뢰찾기
첫 접근은 char[][] 배열을 이용했고, 0에 첫째 줄의 숫자를 1에 둘째 줄의 문자를 저장해줬습니다. 이후 순회하며 인접한 범위 내에 *이 있으면 첫 째 줄의 숫자 값을 -1 해주는 방식으로 시뮬레이션을 돌려봤습니다.(근데 어차피 그래봤자 첫 예제에서 밖에 확인못함ㅋㅋ;) 결과론적으론 그냥 바보짓 한 거였습니다.
근데 이걸 "지뢰가 있으면 -1 해준다"에서 느낀 게 반대로 생각해보면, "-1할 값이 있으면 지뢰를 심을 수 있다"가 됩니다. 그런데 문제는 인접한 곳 모두를 따져야 하는 건데, 이건 생각해보니 그냥 인접한 칸 모두에 1 이상의 값이 있으면 되는 거였습니다. 솔직히 이런 그리디한 접근이 떠올랐을 때는 아이디어 한 번 떠올리고 구현하는 데까지 용기가 필요합니다. 그나마 이 문제는 그리디하게 푸는 게 거의 확실하게 느껴져서 괜찮은 편이긴 했지만 저는 바로 검색을 했습니다. 맞길래 바로 그렇게 했습니다. 운이 그냥 개좋았습니다 나이 따-


## 🧐 참고 사항


## 📄 Reference
