### PR TITLE
김영후 69주차

### DIFF
--- a/hoo/week10s/16Week/Main_1194_달이차오른다가자.java
+++ b/hoo/week10s/16Week/Main_1194_달이차오른다가자.java
@@ -1,0 +1,97 @@
+package SSAFY.study.algo.week10s.week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_1194_달이차오른다가자 {
+
+    static class Ms {   // 이동 중인 민식이 표현할 클래스
+        int row;
+        int col;
+        int dist;
+        int havingKey;    // a~f 키를 가지고 있는 지 여부 저장할 값, 비트 형식으로 할 거라 정수로 선언
+
+        public Ms(int row, int col, int dist, int havingKey) {
+            this.row = row;
+            this.col = col;
+            this.dist = dist;
+            this.havingKey = havingKey;    // 각 객체 별로 다른 배열 참조하게 깊은 복사 수행
+        }
+    }
+
+    static int N, M;
+    static char[][] maze;
+
+    public static void main(String[] args) throws IOException {
+        Ms startMs = init();
+        System.out.println(findShortestRoute(startMs));
+    }
+
+    static Ms init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        maze = new char[N][M];
+
+        Ms startMs = new Ms(0, 0, 0, 0);
+        String inputRow;
+        for (int i = 0; i < N; i++) {
+            inputRow = br.readLine();
+            for (int j = 0; j < M; j++) {
+                maze[i][j] = inputRow.charAt(j);
+                if (maze[i][j] == '0') startMs = new Ms(i, j, 0, 0);
+            }
+        }
+
+        return startMs;
+    }
+
+    static int findShortestRoute(Ms startMs) {
+        Queue<Ms> q = new ArrayDeque<>();
+        boolean[][][] isVisited = new boolean[N][M][64];    // 각 열쇠 별 가지고 있는 여부에 따라 이동 거리 저장해주는 배열, 각 열쇠를 가지고 있는 모든 경우를 체크해주기 위해 0~64 값을 가지게 선언
+        q.offer(startMs);
+        isVisited[startMs.row][startMs.col][0] = true;
+
+        int[] dirRow = new int[] {-1, 0, 1, 0};
+        int[] dirCol = new int[] {0, 1, 0, -1};
+        Ms now;
+        while (!q.isEmpty()) {
+            now = q.poll();
+            if (maze[now.row][now.col] == '1') return now.dist;    // 탈출에 성공한 민식이가 이동한 거리 반환
+
+            int nextRow, nextCol;
+            for (int d = 0; d < 4; d++) {
+                nextRow = now.row + dirRow[d];
+                nextCol = now.col + dirCol[d];
+                if (0 > nextRow || N <= nextRow || 0 > nextCol || M <= nextCol || maze[nextRow][nextCol] == '#')
+                    continue;  // 미로 밖이나 벾은 무조건 건너 뜀
+                if (isVisited[nextRow][nextCol][now.havingKey]) continue;   // 지금 열쇠 조합으로 이미 한 번 방문했던 곳은 건너 뜀
+
+                char nextInfo = maze[nextRow][nextCol];
+                if ((int) 'a' <= (int) nextInfo && (int) nextInfo <= (int) 'f') {    // 다음 칸이 열쇠인 경우
+                    int nextKey = 1 << (nextInfo-'a');    // 각 열쇠의 정수형 번호(0~5)에 따라 왼쪽으로 쉬프트해줌, 그리고 현재 민식이가 가진 키에 해당 열쇠를 더해줌
+                    nextKey = now.havingKey | nextKey;
+                    q.offer(new Ms(nextRow, nextCol, now.dist+1, nextKey));
+                    isVisited[nextRow][nextCol][nextKey] = true;
+                } else if ((int) 'A' <= (int) nextInfo && (int) nextInfo <= (int) 'F') {    // 다음 칸이 문인 경우
+                    if ( (now.havingKey & (1 << (nextInfo-'A')) ) == 0 ) continue; // 해당 문을 열기 위해 필요한 열쇠가 없는 경우 건너 뜀
+
+                    q.offer(new Ms(nextRow, nextCol, now.dist+1, now.havingKey));
+                    isVisited[nextRow][nextCol][now.havingKey] = true;
+                } else {    // 나머지 경우는 그냥 바로 진행
+                    q.offer(new Ms(nextRow, nextCol, now.dist+1, now.havingKey));
+                    isVisited[nextRow][nextCol][now.havingKey] = true;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+}

--- a/hoo/week10s/16Week/Main_19238_스타트택시.java
+++ b/hoo/week10s/16Week/Main_19238_스타트택시.java
@@ -1,0 +1,189 @@
+package SSAFY.study.algo.week10s.week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_19238_스타트택시 {
+
+    static int[] dirRow = new int[] { -1, 1, 0, 0 };    // 상, 하, 좌, 우
+    static int[] dirCol = new int[] { 0, 0, -1, 1 };
+
+    static class Taxi {
+        int row;
+        int col;
+        int move;
+
+        public Taxi(int row, int col, int move) {
+            this.row = row;
+            this.col = col;
+            this.move = move;
+        }
+
+        @Override
+        public String toString() { return this.row + " " + this.col + " " + this.move; }
+    }
+    static Taxi mainTaxi;   // 메인으로 움직일 택시
+
+    static class Passenger {
+        int id;
+        int startRow;
+        int startCol;
+        int endRow;
+        int endCol;
+
+        public Passenger(int id, int startRow, int startCol, int endRow, int endCol) {
+            this.id = id;
+            this.startRow = startRow;
+            this.startCol = startCol;
+            this.endRow = endRow;
+            this.endCol = endCol;
+        }
+    }
+    static Passenger takenPassenger;    // 현재 택시에 태운 승객
+    static Map<Integer, Passenger> passengerMap; // 승객을 id로 관리하기 위한 맵
+
+    static int N, M, fuel;
+    static int[][] map;
+
+    public static void main(String[] args) throws IOException {
+        Taxi initTaxi = init();
+        doTaxi(initTaxi);
+    }
+
+    static Taxi init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        fuel = Integer.parseInt(st.nextToken());
+        map = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int startRow = Integer.parseInt(st.nextToken()) - 1;
+        int startCol = Integer.parseInt(st.nextToken()) - 1;
+        Taxi initTaxi = new Taxi(startRow, startCol, 0);
+
+        takenPassenger = null;
+        passengerMap = new HashMap<>();
+        int passengerStartRow, passengerStartCol, passengerEndRow, passengerEndCol;
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            passengerStartRow = Integer.parseInt(st.nextToken()) - 1;
+            passengerStartCol = Integer.parseInt(st.nextToken()) - 1;
+            passengerEndRow = Integer.parseInt(st.nextToken()) - 1;
+            passengerEndCol = Integer.parseInt(st.nextToken()) - 1;
+            Passenger passenger = new Passenger(i + 2, passengerStartRow, passengerStartCol, passengerEndRow, passengerEndCol);
+            passengerMap.put(i + 2, passenger);
+            map[passengerStartRow][passengerStartCol] = i + 2; // 승객의 id를 맵에 저장
+        }
+
+        return initTaxi;
+    }
+
+    static void doTaxi(Taxi initTaxi) {
+        int tookPassengerCount = 0;
+        mainTaxi = initTaxi;
+        while (tookPassengerCount < M) {
+            int toStartFuel = bfs();
+            fuel -= toStartFuel;
+
+            if (fuel < 0) break;
+
+            int toDestFuel = bfs();
+            fuel -= toDestFuel;
+
+            if (fuel < 0) break;
+
+            fuel += toDestFuel * 2;
+            tookPassengerCount++;
+        }
+        if (tookPassengerCount != M) System.out.println(-1);
+        else System.out.println(fuel);
+    }
+
+    static int bfs() {
+        Queue<Taxi> q = new LinkedList<>();
+        Queue<Passenger> passengerQueue = new LinkedList<>();
+        boolean[][] visited = new boolean[N][N];
+        int[] dx = {-1, 1, 0, 0};
+        int[] dy = {0, 0, -1, 1};
+
+        int prevMove = mainTaxi.move;
+        visited[mainTaxi.row][mainTaxi.col] = true;
+        q.add(mainTaxi);
+
+        while (!q.isEmpty()) {
+            Taxi now = q.poll();
+
+            if (fuel - now.move < 0) {
+                return Integer.MAX_VALUE;
+            }
+
+            if (prevMove != now.move && !passengerQueue.isEmpty()) {
+                break;
+            }
+
+            prevMove = now.move;
+
+            if (takenPassenger == null) {
+                int id = map[now.row][now.col];
+                if (id > 1) {
+                    Passenger p = passengerMap.get(id);
+                    passengerQueue.add(p);
+                }
+            } else {
+                if (now.row == takenPassenger.endRow && now.col == takenPassenger.endCol) {
+                    passengerMap.remove(takenPassenger.id);
+                    takenPassenger = null;
+                    mainTaxi = new Taxi(now.row, now.col, 0);
+                    return prevMove;
+                }
+            }
+
+            for (int i = 0 ; i < 4; i++) {
+                int nx = now.row + dx[i];
+                int ny = now.col + dy[i];
+
+                if (0 <= nx && nx < N && 0 <= ny && ny < N) {
+                    if (map[nx][ny] != 1 && !visited[nx][ny]) {
+                        q.add(new Taxi(nx, ny, now.move + 1));
+                        visited[nx][ny] = true;
+                    }
+                }
+            }
+        }
+
+        if (passengerQueue.isEmpty()) {
+            return Integer.MAX_VALUE;
+        }
+
+        takenPassenger = findNearest(passengerQueue);
+        mainTaxi = new Taxi(takenPassenger.startRow, takenPassenger.startCol, 0);
+        map[takenPassenger.startRow][takenPassenger.startCol] = 0;
+        return prevMove;
+    }
+
+    static Passenger findNearest(Queue<Passenger> q) {
+        Passenger target = q.poll();
+
+        while (!q.isEmpty()) {
+            Passenger compare = q.poll();
+            if (compare.startRow < target.startRow) {
+                target = compare;
+            } else if (compare.startRow == target.startRow && compare.startCol < target.startCol) {
+                target = compare;
+            }
+        }
+
+        return target;
+    }
+
+}

--- a/hoo/week10s/16Week/Main_골드4_18223_민준이와마산그리고건우.java
+++ b/hoo/week10s/16Week/Main_골드4_18223_민준이와마산그리고건우.java
@@ -1,0 +1,101 @@
+package SSAFY.study.algo.week10s.week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_골드4_18223_민준이와마산그리고건우 {
+
+    static class Edge implements Comparable<Edge> {
+        int to;
+        int dist;
+
+        public Edge(int to, int dist) {
+            this.to = to;
+            this.dist = dist;
+        }
+
+        @Override
+        public int compareTo(Edge o) {
+            return this.dist - o.dist;
+        }
+
+        @Override
+        public String toString() {
+            return this.to + " " + this.dist;
+        }
+    }
+    static List<List<Edge>> adjEdge;
+    static int V, E, P;
+    static String answer;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        dijkstra();
+        System.out.println(answer);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        V = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+        adjEdge = new ArrayList<>();
+        for (int i = 0; i < V+1; i++) {    // 정점 개수 +1 만큼 리스트 초기화
+            adjEdge.add(new ArrayList<>());
+        }
+        answer = "GOOD BYE";
+
+        for (int i = 0; i < E; i++) {    // 간선 정보 입력받기
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int dist = Integer.parseInt(st.nextToken());
+            adjEdge.get(from).add(new Edge(to, dist));
+            adjEdge.get(to).add(new Edge(from, dist));
+        }
+    }
+
+    static boolean isPassingP(int[] parents) {   // P 정점을 거치는지 판별
+        boolean isPassing = false;
+        int nowIdx = V; // 도착점부터 역추적 시작
+        while (nowIdx != 1) {
+            nowIdx = parents[nowIdx];
+            if (nowIdx == P) {
+                isPassing = true;
+                break;
+            }
+        }
+
+        return isPassing;
+    }
+
+    static void dijkstra() {
+        int[] parents = new int[V+1];   // 경로 추적용 배열
+        int[] distArr = new int[V+1];
+        for (int i = 0; i < V+1; i++) distArr[i] = Integer.MAX_VALUE;
+
+        PriorityQueue<Edge> pq = new PriorityQueue<>();
+        pq.offer(new Edge(1, 0));   // 출발지 넣기
+        distArr[1] = 0;    // 출발지의 거리는 0
+
+        while (!pq.isEmpty()) {
+            Edge edge = pq.poll();
+
+            int nowTo = edge.to;
+            for (int i = 0; i < adjEdge.get(nowTo).size(); i++) {    // 향하고 있는 도로에 대해서
+                Edge connected = adjEdge.get(nowTo).get(i);    // 연결된 도로 하나 뽑음
+                if (distArr[connected.to] >= distArr[nowTo] + connected.dist) {
+                    distArr[connected.to] = distArr[nowTo] + connected.dist;
+                    pq.offer(new Edge(connected.to, distArr[connected.to]));
+                    parents[connected.to] = nowTo;  // 최단 경로가 갱신될 때는 지금 갈 노드의 부모 노드를 현재 노드로 갱신
+                }
+            }
+        }
+//        System.out.println(Arrays.toString(parents));
+        if (isPassingP(parents)) answer = "SAVE HIM";
+    }
+
+}

--- a/hoo/week30s/30Week/Main_2234_성곽.java
+++ b/hoo/week30s/30Week/Main_2234_성곽.java
@@ -1,0 +1,111 @@
+package twentytwentyfive.january.week2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_2234_성곽 {
+    static int[] dirRow = new int[] {0, -1, 0, 1};
+    static int[] dirCol = new int[] {-1, 0, 1, 0};
+
+    static int N, M;
+    static int[][] map; // 각 칸의 벽 정보를 비트로 저장하는 배열
+    static List<Integer> roomAreaList;  // 각 방 번호의 인덱스에 해당 방의 크기 저장하는 리스트
+
+    public static void main(String[] args) throws IOException {
+        init();
+        int[][] roomNumberArr = new int[N][M];  // 각 칸에 방의 번호를 저장해줄 배열
+        int roomNumber = 1;
+        int widestRoom = 0; // 가장 넓은 방의 크기 저장하는 변수
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (roomNumberArr[i][j] != 0) continue; // 이미 방 번호 매겨졌으면 건너 뜀
+                int roomArea = checkRoomArea(i, j, roomNumberArr, roomNumber++);
+                roomAreaList.add(roomArea);
+                widestRoom = Math.max(widestRoom, roomArea);
+            }
+        }
+
+        int widestBrokenWallRoom = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                widestBrokenWallRoom = Math.max(widestBrokenWallRoom, breakWallAndCalcArea(i, j, roomNumberArr));
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(roomNumber-1).append("\n");
+        sb.append(widestRoom).append("\n");
+        sb.append(widestBrokenWallRoom).append("\n");
+        System.out.println(sb);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        map = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) map[i][j] = Integer.parseInt(st.nextToken());
+        }
+        roomAreaList = new ArrayList<>();
+        roomAreaList.add(0);    // 방 번호는 1번부터 시작하므로 0번 방에는 크기 0 넣어줌
+    }
+
+    static int checkRoomArea(int row, int col, int[][] roomNumberArr, int roomNumber) { // 주어진 각 칸 별 벽 정보를 이용해 방의 크기를 확인하는 함수
+        Queue<int[]> q = new ArrayDeque<>();
+        q.offer(new int[] {row, col});
+        roomNumberArr[row][col] = roomNumber;
+
+        int roomArea = 1;   // 방의 넓이
+        int[] now;
+        while (!q.isEmpty()) {
+            now = q.poll();
+
+            // 0 0 0 1  좌 상 우 하 순으로 벽이 있는 경우를 나타내는 비트
+            // 0 0 1 0
+            // 0 1 0 0
+            // 1 0 0 0
+            int nowBit = 1;
+            int nextRow, nextCol;
+            for (int d = 0; d < 4; d++) {
+                nextRow = now[0] + dirRow[d];
+                nextCol = now[1] + dirCol[d];
+                if ( (nowBit & map[now[0]][now[1]]) == nowBit || roomNumberArr[nextRow][nextCol] != 0 ) {  // 만약 해당 방향 벽이 막혀있는 상황이면 못 감
+                    nowBit = nowBit << 1;
+                    continue;
+                }
+                q.offer(new int[] {nextRow, nextCol});
+                roomNumberArr[nextRow][nextCol] = roomNumber;
+                roomArea++; // 방 크기 1 확장
+                nowBit = nowBit << 1;   // 다음 방향의 벽 체크하기 위해 왼쪽으로 한 칸 쉬프트
+            }
+        }
+
+        return roomArea;
+    }
+
+    static int breakWallAndCalcArea(int row, int col, int[][] roomNumberArr) {    // 벽을 부수고 만들 수 있는 가장 큰 방의 크기를 체크하는 함수
+        int maxValue = 0;
+
+        int nextRow, nextCol;
+        for (int d = 0; d < 4; d++) {
+            nextRow = row + dirRow[d];
+            nextCol = col + dirCol[d];
+            if (isOuted(nextRow, nextCol) || roomNumberArr[nextRow][nextCol] == roomNumberArr[row][col]) continue;
+
+            maxValue = Math.max(maxValue, roomAreaList.get(roomNumberArr[row][col]) + roomAreaList.get(roomNumberArr[nextRow][nextCol]));
+        }
+
+        return maxValue;
+    }
+
+    static boolean isOuted(int row, int col) {    // 범위 밖인 건 벽으로 방지가 돼서 굳이 필요 없는 듯
+        if (row < 0 || row >= N || col < 0 || col >= M) return true;
+        return false;
+    }
+
+}

--- a/hoo/week30s/32Week/Main_16987_계란으로계란치기.java
+++ b/hoo/week30s/32Week/Main_16987_계란으로계란치기.java
@@ -1,0 +1,59 @@
+package SSAFY.study.algo.week30s.week32;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main_16987_계란으로계란치기 {
+
+    static int N;
+    static int[][] eggs;
+    static int maxStrikeCount;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        doStrike(0, 0);
+        System.out.println(maxStrikeCount);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        eggs = new int[N][2];
+
+        StringTokenizer st;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            eggs[i] = new int[] {Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())};    // 2번 인덱스는 계란이 깨졌는 지 여부 저장, 0이면 깨진 것 1이면 살아있는 것
+        }
+        maxStrikeCount = 0;
+    }
+
+    static void doStrike(int nowEgg, int strikeCount) {
+        if (nowEgg == N) return;    // 기저, 모든 계란에 대해 수행이 끝난 경우 바로 종료
+        if (eggs[nowEgg][0] == 0) { // 현재 손에 든 계란이 깨진 계란이면 다음 계란으로
+            doStrike(nowEgg+1, strikeCount);
+            return;
+        }
+
+        for (int i = 0; i < eggs.length; i++) {
+            if (i == nowEgg || eggs[i][0] == 0) continue;   // 현재 계란이나 이미 깨진 계란은 건너 뜀
+
+            int tempStrikeCount = strikeCount;
+            int prevNowEgg = eggs[nowEgg][0];   // 현재 손에 든 계란과 내려친 계란의 내려치기 전 내구도
+            int prevAnotherEgg = eggs[i][0];
+            eggs[nowEgg][0] = Math.max(eggs[nowEgg][0] - eggs[i][1], 0); // 계란으로 계란 친 후 남은 내구도 저장(0 이하로 내려가지 않게끔 처리)
+            eggs[i][0] = Math.max(eggs[i][0] - eggs[nowEgg][1], 0);
+            if (eggs[nowEgg][0] == 0) tempStrikeCount++;    // 깨진 계란 있으면 카운트
+            if (eggs[i][0] == 0) tempStrikeCount++;
+            maxStrikeCount = Math.max(maxStrikeCount, tempStrikeCount);
+
+            doStrike(nowEgg+1, tempStrikeCount);    // 현재 손에 든 계란 오른쪽의 계란에 대해 수행
+            eggs[nowEgg][0] = prevNowEgg;   // 깼던 계란 원상복귀
+            eggs[i][0] = prevAnotherEgg;
+        }
+    }
+
+}

--- a/hoo/week60s/69Week/Main_16928_뱀과사다리게임.java
+++ b/hoo/week60s/69Week/Main_16928_뱀과사다리게임.java
@@ -1,0 +1,81 @@
+package twentytwentyfive.january.week2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_16928_뱀과사다리게임 {
+
+    static int N, M;
+    static int[][] board;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        System.out.println(doGame());
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        // 10 11 12 13 14 15 16 17 18 19
+        // 0 1 2 3 4 5 6 7 8 9
+
+        board = new int[10][10];
+        int start, destination; // 사다리나 뱀의 시작점, 끝점
+        for (int i = 0; i < N+M; i++) {
+            st = new StringTokenizer(br.readLine());
+            start = Integer.parseInt(st.nextToken())-1;
+            destination = Integer.parseInt(st.nextToken())-1;
+            board[start/10][start%10] = destination;
+        }
+    }
+
+    static int doGame() {
+        Queue<int[]> q = new ArrayDeque<>();    // 배열의 0, 1번 인덱스 : 행, 열, 2번 인덱스 : 주사위를 굴린 횟수
+        boolean[][][] isVisited = new boolean[10][10][7];   // 주사위를 굴려 나온 칸의 숫자 별 방문 여부를 저장하는 배열
+        q.offer(new int[] {0, 0, 0});   // 출발점으로 되돌아오는 경우는 없으므로 방문체크는 따로 안했음
+
+        int[] now;
+        int nowNumber;
+        while (!q.isEmpty()) {
+            now = q.poll();
+            nowNumber = calcNowNumber(now[0], now[1]);  // 현재 칸의 번호 계산
+
+            int[] nextRowCol;
+            int nextRow, nextCol;
+            for (int i = 1; i <= 6; i++) {  // 1부터 6까지 주사위를 굴려 봄
+                nextRowCol = calcDestinationRowAndCol(nowNumber + i);
+                nextRow = nextRowCol[0];
+                nextCol = nextRowCol[1];
+                if (nextRow == 9 && nextCol == 9) return now[2]+1;
+                if (isVisited[nextRow][nextCol][i]) continue;   // 이미 현재 주사위 값이 나와 방문해봤던 곳이라면 건너 뜀
+
+                isVisited[nextRow][nextCol][i] = true;  // 우선 사다리든 뱀이든 아니든 방문 처리
+                if (board[nextRow][nextCol] == 0) q.offer(new int[] {nextRow, nextCol, now[2]+1});  // 현재 칸이 사다리나 뱀이 아니라면 그냥 큐에 넣고 넘어감
+                else {  // 현재 칸이 사다리나 뱀이라면 이동 처리
+                    int moveNumber = board[nextRow][nextCol];
+                    int[] movedRowCol = calcDestinationRowAndCol(moveNumber);
+                    q.offer(new int[] {movedRowCol[0], movedRowCol[1], now[2]+1});
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    static int calcNowNumber(int row, int col) {    // 현재 칸의 행, 열을 이용해 번호로 변환하는 함수
+        return (row*10) + col;
+    }
+
+    static int[] calcDestinationRowAndCol(int number) { // 도착할 칸의 숫자를 행, 열로 변환하는 함수
+        return new int[] {number/10, number%10};
+    }
+
+}

--- a/hoo/week60s/69Week/Main_2504_괄호의값.java
+++ b/hoo/week60s/69Week/Main_2504_괄호의값.java
@@ -1,0 +1,50 @@
+package SSAFY.study.algo.week60s.week69;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class Main_2504_괄호의값 {
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String input = br.readLine();
+        if (input.length() == 1 || input.charAt(0) == ')' || input.charAt(0) == ']') {  // 애초에 틀린 입력은 바로 0출력 후 종료
+            System.out.println(0);
+            return;
+        }
+
+        System.out.println(calcParentheses(input));
+    }
+
+    static int calcParentheses(String input) {
+        Stack<Character> parenthesesStack = new Stack<>();  // 괄호를 저장하는 스택
+
+        int parenthesesValue = 0;
+        int tempValue = 1;
+        char c;
+        for (int i = 0; i < input.length(); i++) {
+            c = input.charAt(i);
+            if (c == '(' || c == '[') { // 여는 괄호인 경우, 임시 값에 해당 괄호에 해당하는 값 곱해줌
+                parenthesesStack.push(c);
+                tempValue *= (c == '(')? 2:3;
+            } else {
+                if (parenthesesStack.isEmpty() || !isRightParentheses(parenthesesStack.peek(), c)) return 0; // 불가능한 경우 바로 0반환
+
+                if ( (c == ')' && input.charAt(i-1) == '(') || (c == ']' && input.charAt(i-1) == '[') ) parenthesesValue += tempValue;  // 분배법칙? 느낌으로다가 밖에 둘러싸고 있는 값이 안에 곱해진다고 생각하고 더해줌. 근데 중복으로 값이 더해지는 문제가 발생하므로 바로 괄호가 닫히는 경우에만 더해줘야 함.
+                parenthesesStack.pop(); // 괄호쌍에 해당하는 여는 괄호 뽑아냄
+                tempValue /= (c == ')')? 2:3;   // 사용한 괄호의 값만큼 임시값 나눠줌
+            }
+        }
+
+        return (!parenthesesStack.isEmpty())? 0:parenthesesValue;  // 모든 괄호 다 확인했는데 스택에 남은 괄호 있으면 올바른 괄호열이 아니므로 0 반환
+    }
+
+    static boolean isRightParentheses(char uponStack, char c) {
+        if ( (c == ')' &&  uponStack == '(') || (c == ']' && uponStack == '[') ) return true;
+        return false;
+    }
+
+}

--- a/hoo/week60s/69Week/Main_2504_괄호의값왜틀린지모르는코드.java
+++ b/hoo/week60s/69Week/Main_2504_괄호의값왜틀린지모르는코드.java
@@ -1,0 +1,59 @@
+package SSAFY.study.algo.week60s.week69;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class Main_2504_괄호의값왜틀린지모르는코드 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String input = br.readLine();
+        System.out.println(calcParentheses(input));
+    }
+
+    static int calcParentheses(String input) {
+        Stack<char[]> parenthesesStack = new Stack<>();  // 괄호를 저장하는 스택
+        if (input.charAt(0) == ')' || input.charAt(0) == ']') return 0; // 첫 괄호부터 닫는 괄호면 바로 0 반환하고 종료
+        parenthesesStack.push(new char[] {input.charAt(0), 0});
+
+        int parenthesesValue = 0;
+        int index = 1;
+        Stack<Integer> tempValueStack = new Stack<>();  // 괄호에 쌓여있는 올바른 괄호쌍으로 만들어진 숫자를 저장하는 스택
+        while (index < input.length()) {
+            if (input.charAt(index) == '(' || input.charAt(index) == '[') parenthesesStack.push(new char[] {input.charAt(index), (char) index++});    // 여는 괄호는 바로 넣고 넘어감
+            else {
+                int tempValue = 1;
+                if (index - parenthesesStack.peek()[1] != 1) {  // 만약 이번 괄호가 품고있던 다른 괄호쌍이 있으면 그 값들의 합을 tempValue로
+                    int valueInTempValueStack = 0;
+                    while (!tempValueStack.isEmpty()) valueInTempValueStack += tempValueStack.pop();
+                    tempValue = valueInTempValueStack;
+                }
+                int pairIndexValue = parenthesesStack.peek()[1] + index;    // 연속으로 닫히는 괄호라면 두 괄호의 인덱스를 더한 값이 계속 같아야 함.
+                while (true) {  // 닫는 괄호를 마주친 경우
+                    char c = input.charAt(index);
+                    if (parenthesesStack.isEmpty() || !isRightParentheses(parenthesesStack.peek()[0], c)) return 0; // 옳지 않은 괄호열이면 바로 0 반환
+                    if (parenthesesStack.peek()[1] + index != pairIndexValue) break;  // 올바른 괄호쌍이긴 하지만 연속으로 닫히는 괄호가 아니라면 중단
+                    parenthesesStack.pop();
+                    tempValue *= (c == ')')? 2:3;    // 괄호 유형에 따라 값 더해줌
+
+                    index++;
+                    if (index == input.length()) break;   // 모든 괄호를 다 봤다면 중단
+                    c = input.charAt(index);
+                    if (c == '(' || c == '[') break;    // 다음 괄호가 여는 괄호면 반복 중단
+                }
+                tempValueStack.push(tempValue);
+            }
+        }
+        while (!tempValueStack.isEmpty()) parenthesesValue += tempValueStack.pop();
+
+        return (!parenthesesStack.isEmpty())? 0:parenthesesValue;  // 모든 괄호 다 확인했는데 스택에 남은 괄호 있으면 올바른 괄호열이 아니므로 0 반환
+    }
+
+    static boolean isRightParentheses(char uponStack, char c) {
+        if ( (c == ')' &&  uponStack == '(') || (c == ']' && uponStack == '[') ) return true;
+        return false;
+    }
+
+}

--- a/hoo/week60s/69Week/Main_3101_토끼의이동.java
+++ b/hoo/week60s/69Week/Main_3101_토끼의이동.java
@@ -1,0 +1,89 @@
+package SSAFY.study.algo.week60s.week69;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class Main_3101_토끼의이동 {
+
+    static int N, K;
+    static String jumps;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        if (N == 1) System.out.println(1);
+        else doJump();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        jumps = br.readLine();
+    }
+
+    static void doJump() {
+        long sum = 1L;   // 토끼가 방문한 칸의 값 합, 첫 번째 칸이 1이므로 1이 초기값임
+        Map<Character, int[]> jumpMap = makeJumpMap();
+        long[] startNumbers = makeStartNumbers();
+
+        int[] now = new int[] {0, 0};    // 처음 토끼의 위치로 초기화
+        int[] dirArr;
+        int nextRow, nextCol;
+        for (int i = 0; i < K; i++) {   // 토끼의 점프마다 수행
+            dirArr = jumpMap.get(jumps.charAt(i));
+            nextRow = now[0] + dirArr[0];
+            nextCol = now[1] + dirArr[1];
+            sum += calcAxisValue(startNumbers, nextRow, nextCol);
+
+            now[0] = nextRow;   // 좌표 갱신
+            now[1] = nextCol;
+        }
+
+        System.out.println(sum);
+    }
+
+    static Map<Character, int[]> makeJumpMap() {
+        Map<Character, int[]> jumpMap = new HashMap<>();
+        jumpMap.put('U', new int[] {-1, 0});    // 상 우 하 좌
+        jumpMap.put('R', new int[] {0, 1});
+        jumpMap.put('D', new int[] {1, 0});
+        jumpMap.put('L', new int[] {0, -1});
+
+        return jumpMap;
+    }
+
+    static long[] makeStartNumbers() {  // 각 대각선 별 시작 번호
+        long[] startNumbers = new long[2*N-1];
+        startNumbers[0] = 1L;
+
+        long nowNumber = 1L;
+        long diff = 1L;
+        for (int i = 1; i < 2*N-1; i++) {
+            nowNumber += diff;
+            startNumbers[i] = nowNumber;
+            if (i < N) diff++;
+            else diff--;
+        }
+
+        return startNumbers;
+    }
+
+    static long calcAxisValue(long[] startNumbers, int row, int col) {   // 해당 좌표의 값 계산
+        // row + col이 몇이냐에 따라 정해짐.
+        // row+col이 N 이하일 때는 각 대각선의 시작 숫자가 계차 수열 일반항이 (row+col)인 수열을 이룸. ( 수열 일반항 : ( ((row+col)+1)(row+col) + 2 )/2 )
+        // row+col이 N 초과일 떄는 각 대각선의 시작 숫자가 계차 수열 일반항이 2N-(row+col)인 수열을 이룸. (수열 일반항 :
+        // 수열 일반항은 머리 터질 거 같아서 걍 대각선 개수만큼 대각선 시작숫자 만들어줌 => startNumbers 배열 만들어 주는 걸로 대체
+        long axisValue = startNumbers[row+col]; // 일단 해당 대각선의 시작 숫자 가져옴
+        axisValue += ((row+col)%2 == 1)? (long)row:(long)col;      // 그 후 홀수 번째 대각선인 지 짝수 번째 대각선인 지에 따라 row 또는 col값 더해줌
+        axisValue -= Math.max(0L, (long) (row+col)-N+1);    // 마지막으로 만약 N번째 대각선 이후의 값인 경우, 실제로는 row나 col 값보다 적게 더해져야 하므로 줄어든 대각선 크기만큼 값을 빼줌
+
+        return axisValue;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #396 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
**토끼의 이동**
문제를 보자마자 든 생각은 칸마다 숫자를 만들어줘야 하는가? 였는데, N이 10만입니다. 칸마다 값을 넣어주는 것은 하지 말라는 것입니다. 또, 주어지는 점프의 횟수도 30만이라 주어지는 점프마다 이동하는 좌표의 값을 그때그때 바로 계산해낼 수 있어야 한다는 것을 알았습니다.
그럼 저희는 행, 열이 주어졌을 때 그 행, 열에 해당하는 칸의 값을 계산하는 일반식을 유도해야 합니다. 문제에서는 대각선을 기준으로 값이 나열이 되어있는데요, N의 크기에 따라 그 값들의 변화도 생각해주어야 합니다.

우선 가장 먼저 생각해볼 수 있는 건, 각 대각선의 길이에 대한 부분입니다. 저는 가장 왼쪽 위 꼭지점을 0번 대각선, 그 아래로 오름차순으로 번호를 매겨주어 가장 오른쪽 아래 꼭지점은 2*N-1번 대각선이 됩니다. 중간의 가장 긴 대각선은 N번 대각선이 되구요. 이때 대각선의 길이는 N번 대각선을 기점으로 전에는 증가, 후에는 감소를 합니다. 이 부분을 1번으로 생각하겠습니다.

그 후 각 대각선의 홀, 짝 번호에 따른 방향에 대해 생각해볼 수 있습니다. 홀수 대각선은 오른쪽으로 갈 수록 숫자가 증가, 짝수 대각선은 왼쪽으로 갈 수록 숫자가 증가합니다. 즉, 홀수 대각선은 col만큼 숫자가 증가, 짝수 대각선은 row만큼 숫자가 증가하는 것입니다. 그런데 여기서 주의할 건 N번 대각선까지는 단순히 대각선의 시작 숫자부터 값을 알고자하는 칸의 row, col만큼 숫자를 증가시키면 되지만 N+1번 대각선부터는 조정이 필요하다는 것입니다. N+1번 대각선은 우리가 구한 값보다 실제로는 1만큼 작을 것이며, N+2번 대각선은 2만큼, ... N+n번 대각선은 n만큼 작을 것이라는 겁니다. 단적인 예로 N이 6인 예제에서 10번째 대각선을 보면 34, 35라는 값이 존재합니다. 이때 각 칸의 좌표는 34 = [4, 5], 35 = [5, 4]입니다. 5, 4라는 좌표의 값을 구하고자 대각선의 시작 값인 34에 짝수번째 대각선이니 row만큼의 값을 더했더니 39라는 값이 나옵니다. 이는 35와 다릅니다. 그리하여 여기서 10이 N+4이니 4만큼의 값을 빼주고, 이러면 칸의 값인 35가 나오게 됩니다. 
정리하자면 N번 대각선까지는 대각선의 시작 값과 row, col을 이용해 단순히 더해주고 빼주는 계산이 가능하지만, 그 이후 대각선에서는 대각선의 길이가 감소하므로 단순한 계산 이후의 줄어든 대각선 크기 만큼 조정이 필요하다는 말씀입니다.

마지막으로 각 대각선의 시작 숫자에 대해 생각해보아야 합니다. 고등학교 때 배운 계차수열이라는 개념을 기억하실 지 모르겠습니다. 각 대각선의 시작 값은 N이 6일 경우 1, 2, 4, 7, 11, 16, 22 / 27, 31, 34, 36 과 같습니다. 제가 /로 끊기 전의 수열을 보시면 각 항의 차가 a2-a1 = 1, a3-a2 = 2, ..., a7-a6 = 6과 같이 규칙을 이루는 것을 볼 수 있습니다. 이렇게 수열이 주어졌을 때 각 항의 차가 이루는 수열을 계차수열이라고 하며, 이 문제에서는 이 계차수열을 일반항으로 유도할 수 있습니다. /로 끊은 이후의 수열을 보시면 각 항의 차가 a8-a7 = 5, a9-a8 = 4, ..., a11-a10 = 2와 같이 이 역시 규칙을 이루어 일반항으로 유도할 수 있습니다. 일반항을 이용해 풀이를 하면 메모리도 아끼고 좋겠지만 머리가 거부해서 저는 그냥 규칙성을 이용해 각 대각선의 시작 값을 미리 저장하기로 했습니다. 그리하여 N이 주어졌을 때, 가장 길이가 긴 대각선 직후인 N+1번 대각선까지는 1씩 증가하는 계차를 이용, N+2번 대각선부터는 1씩 줄어드는 계차를 이용하여 각 대각선의 시작 값을 미리 저장해주었습니다.

이제 저희에게는 각 대각선의 시작 값과 각 행, 열이 주어졌을 때 계산 방법이 있으니 이를 이용해 계산을 해주면 됩니다. 각 행의 row+col에 +1을 해주면 대각선의 번호가 됩니다. 그를 통해 시작 값을 찾아주고, 짝수번째 혹은 홀수번째 대각선인 지 여부에 따라 row나 col값을 더해준 다음, N+1번 대각선 이후의 대각선이라면 N을 넘어선 값 만큼 빼주면 해당 칸의 값이 나오게 됩니다.

문제를 푼 후에 중요하게 생각됐던 부분은 규칙을 찾아내고 일반화할 수 있는가? 였습니다. 교육과정에서 규칙성을 경우를 나누는 것과 함께 중요하게 가르쳐왔던 이유가 있는 부분임을 개발자가 되고자하는 과정에서 자주 깨닫게 되는 것 같습니다.

---
**뱀과 사다리 게임**
 bfs로 해결을 했습니다. 우선 게임판의 각 칸은 row*10 + col 에 해당하는 값을 가진다고 생각하고 2차원 int[][] 배열로 만들어주었습니다. 이후 입력 받는 뱀, 사다리의 정보를 뱀, 사다리인 지 여부를 따지지 않고 출발지 칸에 도착지 칸의 번호만 저장해주었습니다.
 bfs에서의 각 poll()마다 1~6의 칸 이동을 수행하며, 이 칸이 이미 방문했던 칸인 지 아닌 지를 체크합니다.(저는 3차원 배열을 통해 이 칸에 어떤 눈이 나와서 이동했는 지를 다 체크해줬는데, 생각해보니 어차피 bfs라서 최단 이동 횟수는 보장되니 그럴 필요는 없었습니다.) 이때 방문했던 칸이 아니라면 칸으로 이동을 해줍니다.
 이동한 칸에 방문체크를 해준 후 이 칸이 뱀, 사다리라면 목적지 칸으로 이동처리를 해줍니다. 이때 뱀, 사다리를 타고 이동한 칸의 방문 체크는 하지 않습니다. 이렇게 목적지인 9행 9열에 도착할 때까지 bfs를 수행해주어 문제를 해결했습니다.

---
**괄호의 값**
재귀 혹은 스택으로 해결을 해야겠다고 생각했고 스택으로 풀이했습니다. 처음 푼 방식이 조금 코드가 난잡하긴 한데, 어떤 반례가 있는 지를 모르겠습니다. 그래서 그냥 처음부터 다시 차근차근 짜서 해결했습니다.
다시 짠 코드에서는 이전에 복잡하게 짰던 부분에 대해 다시 생각해봤습니다. 그런데 이게 괄호 안에 괄호가 있는 경우를 분배법칙이랑 똑같이 생각해줄 수 있겠다는 생각이 들었습니다. 예를 들면 ( () [] ) 과 같은 경우 2 * (2 + 3) 이니까 4 + 6으로 풀 수 있는 것처럼 그냥 애초에 괄호를 여는 순간 2를 곱해준 값들을 더해주면 된다(?)는 것입니다. 그런데 이렇게 하면 주의해야할 점이, ( ( () ) ) 과 같은 부분에서, 괄호가 닫힐 때마다 최종 정답에 값을 + 해주면 2 ( 2 (2) ) ) 라서 8 + 4 + 2와 같이 중복된 연산이 됩니다. 그래서 ()나 []과 같이 괄호가 열리자마자 닫힐 때만 최종 정답에 값을 + 해주는 식으로 하여 2 ( 2 (2) ) )와 같은 경우도 8만 더하게 해주었습니다. 괄호가 열릴 때는 임시 값에 괄호 값에 해당하는 값을 곱해주고, 스택에 여는 괄호를 push 해줍니다. 괄호가 닫히는 모든 경우에는 열릴 때 곱해줬던 값을 다시 나누어 주고, 스택에 넣었던 여는 괄호를 pop()해주었습니다.
정리해서 말씀드리자면, 1. 괄호가 열릴 때 바로 해당 괄호에 해당하는 값을 임시 값에 곱해주며 스택에 해당 여는 괄호를 넣어준다. 2. 바로 괄호가 닫히는 경우에 이때까지 쌓인 임시 값을 더해준다. 3. 괄호가 닫히는 모든 경우에는 해당 괄호에 해당하는 값을 임시 값에서 다시 나누어 주며, 스택에서 해당 닫는 괄호와 짝을 이루는 여는 괄호를 빼준다.
와 같은 풀이 방식이 되겠습니다. 전체적인 로직은 이렇고, 닫는 괄호일 때 스택 맨위의 괄호와 짝이 맞는 지 확인해주고 또 마지막에 스택이 비었는 지도 확인해주셔야 해요. 안 비었으면 여는 괄호랑 짝이 다 안맞춰진 거라 불가능한 경우입니다.

## 🧐 참고 사항


## 📄 Reference

