### PR TITLE
김영후 72주차

### DIFF
--- a/hoo/week70s/72Week/Main_1106_호텔.java
+++ b/hoo/week70s/72Week/Main_1106_호텔.java
@@ -1,0 +1,94 @@
+package SSAFY.study.algo.week70s.week72;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_1106_호텔 {
+
+    static class CostAndCustomer implements Comparable<CostAndCustomer> {
+        int cost;   // 지금까지 쓴 돈
+        int customer;   // 지금까지 유치한 고객 수
+
+        public CostAndCustomer(int cost, int customer) {
+            this.cost = cost;
+            this.customer = customer;
+        }
+
+        @Override
+        public int compareTo(CostAndCustomer c) {
+            if (c.customer == this.customer) return this.cost - c.cost;  // 유치한 고객 수가 같다면 비용 낮은 순 정렬
+
+            return c.customer - this.customer;  // 유치한 고객 기준 내림차순 정렬
+        }
+
+        @Override
+        public String toString() { return this.cost + " " + this.customer; }
+    }
+
+    static int C, N;
+    static int minCost;
+    static int[] isChecked; // 해당 고객 수에 대한 비용이 이미 체크됐는 지 여부 저장
+    static List<CostAndCustomer> costAndCustomerList;
+    static PriorityQueue<CostAndCustomer> costAndCustomersPq;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        calcMinCostToGetCustomer();
+        System.out.println(minCost);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        C = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        minCost = Integer.MAX_VALUE;
+
+        isChecked = new int[1_101]; // 왜 1100이냐? => 1000으로 하면 1원에 3명 가능할 때 딱 999명 채운 다음에 1002명을 채우는 경우를 고려 못해줌
+        Arrays.fill(isChecked, Integer.MAX_VALUE);
+        costAndCustomerList = new ArrayList<>();
+        costAndCustomersPq = new PriorityQueue<>();
+        int cost, customer;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            cost = Integer.parseInt(st.nextToken());
+            customer = Integer.parseInt(st.nextToken());
+            if (isChecked[customer] <= cost) continue;   // 이미 더 저렴한 금액에 고객 유치했으면 건너 뜀
+
+            isChecked[customer] = cost;
+            costAndCustomerList.add(new CostAndCustomer(cost, customer));
+            costAndCustomersPq.offer(costAndCustomerList.get(costAndCustomerList.size()-1));
+            if (customer >= C) minCost = Math.min(minCost, cost);
+        }
+        Collections.sort(costAndCustomerList);  // 기준에 따라 정렬
+    }
+
+    static void calcMinCostToGetCustomer() {
+        CostAndCustomer now;
+        while (!costAndCustomersPq.isEmpty()) {
+            now = costAndCustomersPq.poll();
+
+            for (CostAndCustomer c : costAndCustomerList) {    // 각 호텔 별 고객과 비용에 대해
+                int multiplier = 1; // 배수 1부터 곱해가며 고객 수 초과 안할 때까지 삽입
+                int nextCustomer, nextCost;
+                while (true) {
+                    nextCustomer = now.customer + (c.customer * multiplier);
+                    nextCost = now.cost + (c.cost * multiplier);
+                    if (nextCustomer > 1_100) break;    // 구하고자 하는 고객 수 넘었으면 멈춤
+                    if (isChecked[nextCustomer] <= nextCost) {   // 이미 더 저렴한 비용으로 처리 가능하면 건너 뜀
+                        multiplier++;
+                        continue;
+                    }
+                    isChecked[nextCustomer] = nextCost;
+                    costAndCustomersPq.offer(new CostAndCustomer(nextCost, nextCustomer));
+
+                    if (nextCustomer >= C) minCost = Math.min(minCost, nextCost);
+                    multiplier++;   // 배수해줄 숫자 +1
+                }
+            }
+        }
+    }
+
+}

--- a/hoo/week70s/72Week/Main_1647_도시분할계획.java
+++ b/hoo/week70s/72Week/Main_1647_도시분할계획.java
@@ -1,0 +1,88 @@
+package SSAFY.study.algo.week70s.week72;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_1647_도시분할계획 {
+
+    static class Road implements Comparable<Road> {
+        int from;
+        int to;
+        int cost;
+
+        public Road(int from, int to, int cost) {
+            this.from = from;
+            this.to = to;
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo(Road r) { return this.cost - r.cost; } // 비용 기준 오름차순 정렬
+    }
+
+    static int N, M;
+    static PriorityQueue<Road> pq;
+    static int[] parent;    // 각 노드의 부모 노드 저장할 배열
+
+    public static void main(String[] args) throws IOException {
+        init();
+        System.out.println(calcMinSpanningTreeCost());
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        pq = new PriorityQueue<>();
+        int from, to, cost;
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            from = Integer.parseInt(st.nextToken());
+            to = Integer.parseInt(st.nextToken());
+            cost = Integer.parseInt(st.nextToken());
+
+            pq.offer(new Road(from, to, cost));
+        }
+
+        parent = new int[N+1];
+        for (int i = 1; i <= N; i++) parent[i] = i; // 우선 자기 자신의 부모는 자기 자신으로 초기화
+    }
+
+    static int calcMinSpanningTreeCost() { // 모든 정점을 최소 비용으로 잇는 스패닝 트리 생성 하고 그 트리의 가중치를 계산하는 함수
+        int totalCost = 0;  // 스패닝 트리의 총 비용
+        int maxCost = 0;    // 스패닝 트리에 포함된 길의 비용 중 가장 큰 비용
+        Road now;
+        while (!pq.isEmpty()) {
+            now = pq.poll();
+            if (union(now.from, now.to)) continue;  // 이미 연결된 경로가 있는 경우, 연결하지 않고 건너 뜀
+            totalCost += now.cost;
+            maxCost = Math.max(maxCost, now.cost);  // 스패닝 트리에 포함할 도로를 이용, 최대 비용 갱신
+        }
+
+        return totalCost - maxCost;
+    }
+
+    static int find(int a) {
+        if (parent[a] == a) return a;   // 부모가 자기 자신이면 바로 반환
+
+        return parent[a] = find(parent[a]); // 아니라면 재귀적으로 부모 찾으며 경로 압축
+    }
+
+    static boolean union(int x, int y) {
+        int parentX = find(x);
+        int parentY = find(y);
+
+        if (parentX != parentY) {   // 부모가 서로 다르다면 거짓 반환
+            if (parentX < parentY) parent[parentY] = parentX;   // 일관성 위해 마을 번호 더 작은 쪽으로 합쳐줌
+            else parent[parentX] = parentY;
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/hoo/week70s/72Week/Main_2616_소형기관차.java
+++ b/hoo/week70s/72Week/Main_2616_소형기관차.java
@@ -1,0 +1,50 @@
+package SSAFY.study.algo.week70s.week72;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main_2616_소형기관차 {
+
+    static int N;
+    static int[] passengers;    // 누적합 형태로 승객 수 저장
+    static int carLimit;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        calcMaxPassenger();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        passengers = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        passengers[0] = Integer.parseInt(st.nextToken());
+        for (int i = 1; i < N; i++) {
+            passengers[i] = Integer.parseInt(st.nextToken());
+            passengers[i] += passengers[i-1];
+        }
+
+        carLimit = Integer.parseInt(br.readLine());
+    }
+
+    static void calcMaxPassenger() {    // start: 시작 칸 번호, count: 배정한 기관차 수
+        int[][] dpArr = new int[3][N];
+        for (int i = 0; i < N; i++) {    // 첫 기관차가 끌 수 있는 최대 칸 수만큼의 차량들에 대해
+            if (i < carLimit) dpArr[0][i] = Math.max(dpArr[0][Math.max(0, i-1)], passengers[i]); // 최대로 끌 수 있는 차량 칸보다 적은 수에서는 이때까지 끌 수 있는 누적합 바로 저장
+            else dpArr[0][i] = Math.max(dpArr[0][i-1], passengers[i]-passengers[i-carLimit]);
+        }
+
+        for (int i = 1; i < 3; i++) {   // 나머지 두대의 기관차에 대해
+            for (int j = carLimit*i; j < N; j++) {  // 각 기관차 이전의 기관차들이 최대로 끈 누적 차량 대수 이후부터 최댓값 갱신
+                dpArr[i][j] = Math.max(dpArr[i][j-1], dpArr[i-1][j-carLimit]+(passengers[j]-passengers[j-carLimit]));
+            }
+        }
+        System.out.println(dpArr[2][N-1]);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close #428 

## ✔️ 문제 풀이 진행 사항
올 완

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 도시 분할 계획
두 구역으로 나누는데, 각 구역 내에서도 서로 이어진 경로는 하나만 있으면 된다 => 모든 노드를 싸이클이 없게 연결하고 한 간선을 끊어준다. 근데 최소 비용으로 해라 => 스패닝 트리 만들어주는데, 비용 낮은 애들 우선적으로 해야하니 우선순위 큐 사용

+ 호텔
PQ이용해서 그리디하게? 풀었음. 각 고객 수 별로 드는 비용 저장하는 배열 써서 메모이제이션 느낌이 좀 들어감. 첨에 배열 크기 1_001로 잡아서 틀렸음. 이게 '적어도' C명 늘이는 게 목적이라, C가 1,000이라고 해서 그까지만 구할 게 아니라 이전에 999명 수용했다면 C를 충족 못했으니, 100명 수용 가능한 호텔이라면 1,099명 수용할 때 비용도 고려를 해줘야 해서였음.
근데 풀고 나서 분류 보니 냅색이라고 함. 이런 풀이법을 못 떠올리는 걸 보니 좀 큰일난 듯

+ 소형기관차
처음에는 대충 생각해서 누적합 만들어주고 재귀로 값 구해줬음 -> 시간초과
문제 부류 보고 재귀를 다이나믹 프로그래밍으로 변경

## 🧐 참고 사항

## 📄 Reference
