### PR TITLE
김동우 73주차

### DIFF
--- a/kdw999/73Week/백준_12886_돌그룹.java
+++ b/kdw999/73Week/백준_12886_돌그룹.java
@@ -1,0 +1,95 @@
+package Week73;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static int A, B, C;
+    public static boolean[][] visited;
+    public static int answer = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        A = Integer.parseInt(st.nextToken());
+        B = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        if ((A + B + C) % 3 != 0) { // 3개의 합이 3으로 나눠지지 않으면 불가능
+            System.out.println("0");
+            return;
+        }
+
+        simulate();
+        System.out.println(answer);
+    }
+
+    public static void simulate() {
+        Queue<Node> q = new LinkedList<>();
+
+        // 돌 그룹을 초기 상태로 큐에 넣고 방문 처리
+        visited = new boolean[2001][2001]; // 2001 크기로 설정
+        q.offer(new Node(A, B, C));
+        visited[A][B] = true;
+
+        while (!q.isEmpty()) {
+            Node temp = q.poll();
+            int a = temp.a;
+            int b = temp.b;
+            int c = temp.c;
+
+            if (a == b && b == c) {
+                answer = 1; // 세 값이 같다면 정답은 1
+                return;
+            }
+
+            // 두 값이 다르면 연산 수행
+            if (a != b) {
+                int na = a > b ? a - b : a + a;
+                int nb = a > b ? b + b : b - a;
+
+                if (!visited[na][nb]) {
+                    q.offer(new Node(na, nb, c));
+                    visited[na][nb] = true; // 방문 처리
+                }
+            }
+
+            if (b != c) {
+                int nb = b > c ? b - c : b + b;
+                int nc = b > c ? c + c : c - b;
+
+                if (!visited[nb][nc]) {
+                    q.offer(new Node(a, nb, nc));
+                    visited[nb][nc] = true; // 방문 처리
+                }
+            }
+
+            if (a != c) {
+                int na = a > c ? a - c : a + a;
+                int nc = a > c ? c + c : c - a;
+
+                if (!visited[na][nc]) {
+                    q.offer(new Node(na, b, nc));
+                    visited[na][nc] = true; // 방문 처리
+                }
+            }
+        }
+    }
+}
+
+class Node {
+    int a, b, c;
+
+    public Node(int a, int b, int c) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+    }
+}
+

--- a/kdw999/73Week/백준_15565_귀여운라이언.java
+++ b/kdw999/73Week/백준_15565_귀여운라이언.java
@@ -1,0 +1,61 @@
+package Week73;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_15565_귀여운라이언 {
+
+	static int N, K;
+	
+	public static void main(String[] args) throws IOException {
+		init();
+	}
+	
+	private static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		
+		st = new StringTokenizer(br.readLine());
+		
+		String set = ""; // 전체 집합
+ 
+		int result = 987654321;
+		int idx = 0;
+        int num = 0;		
+//		while(st.countTokens() > 0) { // 토큰 갯수만큼 반복
+
+		int[] doll = new int[N];
+		for(int i=0; i<N; i++) {
+			doll[i] =  Integer.parseInt(st.nextToken()); // 인형 정보
+		}
+
+		int left = 0;
+        for(int right=0; right<doll.length; right++) {
+			
+        	if(doll[right] == 1) num++;
+
+
+        	while (num >= K) {
+                result = Math.min(result, right - left + 1); 
+
+                if (doll[left] == 1) {
+                    num--; // 왼쪽 포인터가 가리키는 인형이 라이언이면 개수 감소, 
+                    //다음 라이언 인형을 만나면 left 포인터를 움직이는 반복문에서 탈출하기 위함
+                }
+                left++; // 왼쪽 포인터 이동
+            }
+		}
+//		}
+		
+//		int rs = ryanList.size()-2;
+//		// 라이언 위치로 라이언이 3개인 집합 길이 계산, 인덱스 2칸 차이나면 라이언이 3개
+//		for(int i=0; i<rs; i++) {
+//			result = Math.min((ryanList.get(i+2)- ryanList.get(i))+1, result);
+//		}
+		
+		System.out.println(result == 987654321 ? -1 : result);
+	}
+}

--- a/kdw999/73Week/백준_1707_이분그래프.java
+++ b/kdw999/73Week/백준_1707_이분그래프.java
@@ -1,0 +1,91 @@
+package Week73;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_1707_이분그래프 {
+
+	static int K;
+	static int[] group;
+	 
+	static List<List<Integer>> adjList;
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		K = Integer.parseInt(br.readLine());
+
+		StringBuilder sb = new StringBuilder();
+		StringTokenizer st;
+		
+		for(int k=0; k<K; k++) {
+			st = new StringTokenizer(br.readLine());
+			int V = Integer.parseInt(st.nextToken());
+			int E = Integer.parseInt(st.nextToken());
+			
+			adjList = new ArrayList<>();
+			for(int l=0; l<=V; l++) adjList.add(new ArrayList<>());
+			
+			for(int i=0; i<E; i++) {
+				
+				st = new StringTokenizer(br.readLine());
+				int u = Integer.parseInt(st.nextToken());
+				int v = Integer.parseInt(st.nextToken());
+				
+				adjList.get(u).add(v);
+				adjList.get(v).add(u);
+			}
+			
+			// 이분 그래프 체크
+			if(link(V)) sb.append("YES\n");
+			else sb.append("NO\n");
+		}
+		System.out.println(sb);
+	}
+	
+	private static boolean link(int V) {
+		
+		 group = new int[V+1]; // 정점들이 집합에 속했는지 체크용
+		 // 0 : 집합 소속 X
+		 // 1 : 1집합 소속
+		 // 2 : 2집합 소속
+		
+		for(int i=1; i < adjList.size(); i++) {
+			if(group[i] == 0) {
+				
+				// 연결된 정점이 같은 집합에 속한다면 이분 그래프 X
+				if(!bfs(i)) return false;
+			}
+		}
+		
+		return true;
+	}
+	
+	private static boolean bfs(int start) {
+		
+		Queue<Integer> q = new ArrayDeque<>();
+		q.add(start);
+		group[start] = 1; // 첫 노드는 집합1로
+		
+		while(!q.isEmpty()) {
+			
+			int node = q.poll(); // 현재 정점
+			int groupNum = group[node]; // 정점이 속한 그룹
+			
+			// 현재 정점이랑 연결된 정점들
+			for(int next : adjList.get(node)) {
+				
+				// 연결된 정점이 아직 그룹에 안속해있다면
+				if(group[next] == 0) {
+					group[next] = -groupNum;
+					q.add(next);
+				}
+				
+				// 연결된 정점이 이미 같은 집합에 속해있으면 이분 그래프 X
+				else if(group[next] == groupNum) return false;
+			}
+		}
+		
+		return true;
+	}
+ 
+}


### PR DESCRIPTION
## 🔍 개요

+ close #436 

## 📝 문제 풀이 전략 및 실제 풀이 방법
### 큐티 라이언

범위가 넓기 때문에 시간초과를 피하기 위해 한 번의 연산으로 풀어주려했음
라이언 인형 갯수가 K개 이상이 됐을 때 제일 오른쪽 라이언의 인덱스와 제일 왼쪽 라이언의 길이를 빼서 집합의 길이를 구했주었다.
그러나 처음 이렇게 풀 때 인형들의 번호를 문자열로 더해가면서 subString으로 만들어진 인형들의 번호를 잘라내서 오른쪽, 왼쪽 인덱스 위치값을 빼주는 식으로 계산해주었는데
반복문 하나의 연산이더라도 subString으로 문자열을 잘라내는 방식이 매 번 O(N)의 계산을 하기 때문에 시간초과가 났음

그래서 인형 번호를 더해서 문자열로 필요부분만 자르는 것이 아닌 번호를 배열에 저장해놓고 오른쪽, 왼쪽  라이언의 인덱스를 한 칸씩 
증가시켜주면서 집합의 길이를 계산해줌

### 돌 그룹

A B, B C, A C 세 경우로 문제에서 제시하는 계산식을 사용해 새로운 수를 만들고 세 수가 같아지는지 계속 비교해주면 된다.
새로운 수들을 큐에 넣으면서 사용하는데 방문처리 해주지 않으면 메모리 문제가 생김 A B C 그룹이 3개라 3차원 배열로 방문처리해주면
메모리 초과가 뜲, 처음엔 set으로 중복처리 했었는데 도대체 뭐가 문제인지 몰라서 해결 못함

힌트로는 2차원 배열을 이용했는데 문제의 계산식은 두 수를 이용해서 새로운 수 2개를 만들기 때문에 2차원 배열로 방문처리를 해주었음
방문처리만 해결되면 나머지 연산 과정은 문제의 방식에 따라 더 큰 수, 작은 수에 따라 계산해주면된다.

### 이분 그래프

정점을 두 그룹으로 나눴을 때 같은 그룹에 연결된 정점이 있으면 안되는 이분 그래프 문제
두 정점들이 속한 그룹을 2개의 List로 나눠서 contains로 한 정점의 연결된 다른 정점들이 같은 그룹에 속했는지 체크해주려 했음
그러나 모든 정점에서 탐색을 시작하는 문젠데 매 번 객체 2개를 사용하여 정점들의 상태를 관리하려니까 복잡한 면이 없지 않아서
하나의 배열에다가 값(0, 1, 2)에 따라 그룹을 나눠주었음

1번 정점에 연결된 다른 정점들을 BFS로 체크해주면서 아직 그룹에 속하지 않았다면 1번과는 다른 값을 부여해주고
그룹에 속했는데 1번과 같은 값이라면 이분 그래프의 조건에 해당되지 않기에 탐색을 멈춘다.
해당 방법으로 마지막 정점까지 탐색해주면 된다.
   

## 🧐 참고 사항
ex) 이런 이런 이유로 못 풀었습니다ㅜㅜ, 이런 문제를 풀 때 좋은 참고 블로그를 밑에 링크할게요!, 등등 ...

## 📄 Reference
[돌그룹 참고](https://passionfruit200.tistory.com/657)


