### PR TITLE
김동우 77주차

### DIFF
--- a/kdw999/77Week/PGS_숫자 짝꿍.java
+++ b/kdw999/77Week/PGS_숫자 짝꿍.java
@@ -1,0 +1,28 @@
+import java.util.*;
+
+class Solution {
+   public String solution(String X, String Y) {
+	     
+       int[] xArr = new int[10];
+       int[] yArr = new int[10];
+
+       for(int i=0; i<X.length(); i++) xArr[X.charAt(i)- 48]++;
+       for(int i=0; i<Y.length(); i++) yArr[Y.charAt(i)- 48]++;
+       
+       String result = "";
+       
+       for(int i=9; i>=0; i--) {
+           if(xArr[i] >= 1 && yArr[i] >= 1){
+               
+               int min = Math.min(xArr[i], yArr[i]);
+            
+               result += String.valueOf(i).repeat(min);
+               // for(int j=0; j<min; j++) result += String.valueOf(i).repeat(min);
+           }
+       }
+       
+       if(result.equals("")) return "-1";
+       else if(result.charAt(0) == '0') return "0";
+       else return result;
+	    }
+}

--- a/kdw999/77Week/백준_12865_평범한배낭.java
+++ b/kdw999/77Week/백준_12865_평범한배낭.java
@@ -1,0 +1,50 @@
+package Week77;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_12865_평범한배낭 {
+	
+	static int N, K;
+	static int[] DP;
+	static int[] W, V;
+	
+	public static void main(String[] args) throws IOException {
+		init();
+		solve();
+	}
+	
+	private static void solve() {
+		
+		for(int i=1; i<=N; i++) {
+			for (int j = K; j >= W[i]; j--) {
+				
+				DP[j] = Math.max(DP[j], DP[j - W[i]] + V[i]);
+				
+			}
+		}
+		
+		System.out.println(DP[K]);
+	}
+	
+	private static void init () throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		
+		DP = new int[K+1];
+		W = new int[N+1];
+		V = new int[N+1];
+		
+		for(int i=1; i<=N; i++) {
+			st = new StringTokenizer(br.readLine());
+			
+			W[i] = Integer.parseInt(st.nextToken());
+			V[i] = Integer.parseInt(st.nextToken());
+			
+		}
+		
+	}
+}

--- a/kdw999/77Week/백준_9205_맥마걸.java
+++ b/kdw999/77Week/백준_9205_맥마걸.java
@@ -1,0 +1,100 @@
+package Week77;
+
+import java.io.*;
+import java.util.*;
+
+public class 백준_9205_맥마걸{
+	
+	static class Convenient{
+		
+		int x;
+		int y;
+		
+		public Convenient (int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+ 
+	}
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int t=0; t<T; t++) {
+			
+			int n = Integer.parseInt(br.readLine()); // 편의점
+		
+			int homeX = 0, homeY = 0;
+			int festivalX= 0, festivalY = 0;
+			
+			Convenient[] store = new Convenient[n]; 
+			
+			for(int i=0; i<n+2; i++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				
+				int x = Integer.parseInt(st.nextToken());
+				int y = Integer.parseInt(st.nextToken());
+				
+				// 상근 집
+				if(i==0) {
+					homeX = x;
+					homeY = y;
+				}
+				
+				// 페스티벌 좌표
+				else if(i==n+1) {
+					festivalX = x;
+					festivalY = y;
+				}
+				
+				// 편 좌
+				else {
+					store[i-1] = new Convenient(x, y);
+				}
+			}
+			
+			 
+		
+				Queue<Convenient> q = new ArrayDeque<>();
+				boolean visited[] = new boolean[n]; // 방문처리
+				
+				q.offer(new Convenient(homeX, homeY));
+				
+				boolean flag = false;
+				
+				while(!q.isEmpty()) {
+					
+					Convenient c = q.poll();
+					
+					// 현재 위치에서 페스티벌 도착하는 지 체크
+					if(Math.abs(festivalX - c.x) + Math.abs(festivalY - c.y) <= 1000) {
+						sb.append("happy\n");
+						flag = true;
+						   break;
+					}
+					
+					// 현재 위치에서 이동 가능한 모든 편의점 방문
+					for(int i=0; i<n; i++) {
+						
+						if(Math.abs(store[i].x - c.x) + Math.abs(store[i].y - c.y) <= 1000) {
+							if(!visited[i]) {
+								q.offer(new Convenient(store[i].x, store[i].y));
+								visited[i] = true;
+							}
+						}
+					}
+ 
+				}
+				
+				// 페스티벌에 도착하지 못한 경우
+				if(!flag) {
+					sb.append("sad\n");
+				}
+				 
+		} // T
+		System.out.println(sb);
+	}
+}


### PR DESCRIPTION
## 🔍 개요

+ close #461 



## 📝 문제 풀이 전략 및 실제 풀이 방법
### 맥주 마시며 걸어다니기

현재 위치에서 이동 가능한 편의점들을 큐에 넣는 식의 BFS 탐색으로 풀어도 될 것 같았으나 문제를 읽어보면 최적의 위치 이동이 아닌
단순 페스티벌장에 갈 수 있는가 없는가 판단하는 문제로 느껴져서 편의점의 좌표를 오름차순 정렬시키고 모든 편의점을 방문하면서 페스티벌장에 도착할 수 있는가를 판단해주는 식으로도 풀이가 될 것 같았다.

이게 최적의 이동 경로는 아니더라도 도착만 하면 되는 거니까
근데 틀렸음 왜지? 정렬함으로써 이동 경로를 고정시켜버리면 도착할 수 있는게 도착하지 못하는 경우가 생기는 것 같음

그래서 결국 처음에 생각한대로 현재 위치에서 편의점 좌표를 BFS 탐색하면서 풀어주었음

### 숫자 짝꿍

문자 X, Y를 하나씩 읽으면서 배열에다가 해당 숫자의 갯수를 카운팅해줌
카운팅한 배열에 갯수에 따라 해당 숫자를 문자열에 추가

for문을 통한 += 연산 작업은 시간초과에 걸려 String.repeat() 사용하였음, Stringbuilder.append()도 가능

repeat()은 메모리를 미리 확보한 공간에 문자를 복사, 한 번에 문자 추가 → 빠름 (O(n))
for +=는 기존 데이터를 복사 + 새 문자열을 생성하는 과정 반복 → 느림 (O(n²))

즉, repeat()는 한 번에 처리하고, +=는 계속 새로 만드는 차이점

### 평범한 배낭

문제 이름부터 DP 배낭 냄새나는 문제

DP, 무게(W), 가치(V) 배열 따로 만들어주고 K무게의 역순 방향으로 K ~ 0 범위 내에서 DP[ K - W[] +] + V[]로 무게의 최대 가치를 2중 반복문으로 갱신

정순으로 푼다면 두 무게의 합이 K가 넘지 않게 조건 붙여야 할 듯? 

## 🧐 참고 사항
ex) 이런 이런 이유로 못 풀었습니다ㅜㅜ, 이런 문제를 풀 때 좋은 참고 블로그를 밑에 링크할게요!, 등등 ...

## 📄 Reference
[참고 블로그 제목이나 내용?](블로그 링크)

ex) [깃허브 이슈, PR 템플릿 작성 할 때 참고](https://soft.plusblog.co.kr/66)
